### PR TITLE
Add README and localStorage saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Pantin Animateur
+
+Ce projet permet d'animer un pantin SVG directement dans le navigateur. Il est compose d'un fichier HTML minimal et de plusieurs modules JavaScript.
+
+## Fonctionnement general
+
+1. **index.html** charge le fichier SVG `manu.svg` ainsi que le script principal `src/main.js`.
+2. **svgLoader.js** importe le SVG, reparent certains elements pour obtenir une structure coherente et calcule les points pivots utilises pour les rotations.
+3. **timeline.js** gere une liste de *frames*. Chaque frame enregistre la rotation de chaque membre du pantin. Il est possible d'ajouter, supprimer ou lire les frames.
+4. **interactions.js** permet de faire tourner chaque membre a la souris et ajoute des interactions globales (deplacement, rotation et redimensionnement du pantin complet).
+5. **ui.js** affiche une petite interface (boutons de lecture, ajout de frame, import/export...) et synchronise ces actions avec la timeline.
+
+Lors du chargement, `main.js` instancie la timeline, branche les interactions et applique la frame courante sur le SVG. L'etat de l'animation est sauvegarde automatiquement dans `localStorage` apres chaque modification et recharge au demarrage si present.
+
+## Ameliorations apportees
+
+- Lecture de l'animation a partir de la frame courante plutot que depuis le debut.
+- Sauvegarde automatique de la timeline dans `localStorage` et rechargement a l'ouverture de la page.
+
+## Lancer le projet
+
+Ouvrez simplement `index.html` dans un navigateur moderne. Toutes les dependances sont embarquees.
+

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,11 @@ loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
 
   // --- 1. Instancie la timeline (1 frame initiale vierge) ---
   const timeline = new Timeline(memberList);
+  // Chargement éventuel depuis localStorage
+  const saved = localStorage.getItem('animation');
+  if (saved) {
+    try { timeline.importJSON(saved); } catch (e) { console.warn(e); }
+  }
 
   // --- 2. Fonction : appliquer un frame de timeline au SVG ---
   function applyFrameToSVG(frame) {
@@ -34,9 +39,11 @@ setupPantinGlobalInteractions(svgDoc, {
   onChange: () => { /* callback pour undo/redo, sauvegarde, etc. */ }
 });
   // --- 3. Branche les interactions (rotations) ---
-  setupInteractions(svgDoc, memberList, pivots, timeline, () => {
-    // On sauvegarde et réapplique à chaque modif
+  setupInteractions(svgDoc, memberList, pivots, timeline);
+  // Réapplique la frame après chaque modification via interactions
+  svgDoc.addEventListener('mouseup', () => {
     applyFrameToSVG(timeline.getCurrentFrame());
+    localStorage.setItem('animation', timeline.exportJSON());
   });
 
   // --- 4. Branche l'UI ---

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -70,7 +70,7 @@ export class Timeline {
     // callback(frame, index)
     if (this.playing) return;
     this.playing = true;
-    let i = 0;
+    let i = this.current;
     this._interval = setInterval(() => {
       callback(this.frames[i], i);
       i++;

--- a/src/ui.js
+++ b/src/ui.js
@@ -30,28 +30,36 @@ export function initUI(timeline, onFrameChange) {
   }
 
   // ---- Handlers ----
+  function save() {
+    localStorage.setItem('animation', timeline.exportJSON());
+  }
+
   document.getElementById('prevFrame').onclick = () => {
     timeline.prevFrame();
     updateFrameInfo();
     onFrameChange();
+    save();
   };
 
   document.getElementById('nextFrame').onclick = () => {
     timeline.nextFrame();
     updateFrameInfo();
     onFrameChange();
+    save();
   };
 
   document.getElementById('addFrame').onclick = () => {
     timeline.addFrame();
     updateFrameInfo();
     onFrameChange();
+    save();
   };
 
   document.getElementById('delFrame').onclick = () => {
     timeline.deleteFrame();
     updateFrameInfo();
     onFrameChange();
+    save();
   };
 
   document.getElementById('playAnim').onclick = () => {
@@ -66,6 +74,7 @@ export function initUI(timeline, onFrameChange) {
     timeline.stop();
     updateFrameInfo();
     onFrameChange();
+    save();
   };
 
   document.getElementById('exportAnim').onclick = () => {
@@ -95,6 +104,7 @@ export function initUI(timeline, onFrameChange) {
         timeline.importJSON(evt.target.result);
         updateFrameInfo();
         onFrameChange();
+        save();
       } catch (e) {
         alert("Erreur import: " + e.message);
       }


### PR DESCRIPTION
## Summary
- document project structure in README
- persist timeline in localStorage
- start animation playback from current frame
- fix extra parameter call to `setupInteractions`

## Testing
- `node --check src/main.js`
- `node --check src/ui.js`
- `node --check src/timeline.js`
- `node --check src/svgLoader.js`
- `node --check src/interactions.js`


------
https://chatgpt.com/codex/tasks/task_e_688c04b39664832bac9c6e9bfc463755