### PR TITLE
Improve puppet controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ce projet permet d'animer un pantin SVG directement dans le navigateur. Il est c
 1. **index.html** charge le fichier SVG `manu.svg` ainsi que le script principal `src/main.js`.
 2. **svgLoader.js** importe le SVG, reparent certains elements pour obtenir une structure coherente et calcule les points pivots utilises pour les rotations.
 3. **timeline.js** gere une liste de *frames*. Chaque frame enregistre la rotation de chaque membre du pantin. Il est possible d'ajouter, supprimer ou lire les frames.
-4. **interactions.js** permet de faire tourner chaque membre a la souris et ajoute des interactions globales (deplacement, rotation et redimensionnement du pantin complet).
+4. **interactions.js** permet de faire tourner chaque membre a la souris et gère le déplacement, l'échelle et la rotation du pantin complet.
 5. **ui.js** affiche une petite interface (boutons de lecture, ajout de frame, import/export...) et synchronise ces actions avec la timeline.
 
 Lors du chargement, `main.js` instancie la timeline, branche les interactions et applique la frame courante sur le SVG. L'etat de l'animation est sauvegarde automatiquement dans `localStorage` apres chaque modification et recharge au demarrage si present.
@@ -16,6 +16,7 @@ Lors du chargement, `main.js` instancie la timeline, branche les interactions et
 
 - Lecture de l'animation a partir de la frame courante plutot que depuis le debut.
 - Sauvegarde automatique de la timeline dans `localStorage` et rechargement a l'ouverture de la page.
+- Ajout de curseurs pour ajuster la rotation et l'échelle du pantin.
 
 ## Lancer le projet
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
     #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
     #frameInfo { margin: 0 14px; font-weight: bold; }
+    #theatre { width: 100%; height: 80vh; position: relative; overflow: hidden; }
+    #theatre object { width: 100%; height: 100%; display: block; }
   </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
       setRotation(el, angle, pivot);
     });
   }
-setupPantinGlobalInteractions(svgDoc, {
+const pantinControls = setupPantinGlobalInteractions(svgDoc, {
   rootGroupId: "manu_test",   // ton groupe racine
   grabId: "torse",             // id du torse pour le centre et le handle
   onChange: () => { /* callback pour undo/redo, sauvegarde, etc. */ }
@@ -49,7 +49,7 @@ setupPantinGlobalInteractions(svgDoc, {
   // --- 4. Branche l'UI ---
   initUI(timeline, () => {
     applyFrameToSVG(timeline.getCurrentFrame());
-  });
+  }, pantinControls);
 
   // --- 5. Première application ---
   applyFrameToSVG(timeline.getCurrentFrame());

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,7 +6,7 @@
  * @param {Timeline} timeline - instance de Timeline
  * @param {Function} onFrameChange - callback appelée après chaque modif (ex: pour réappliquer la frame sur le SVG)
  */
-export function initUI(timeline, onFrameChange) {
+export function initUI(timeline, onFrameChange, pantinControls) {
   const controls = document.getElementById('controls');
   controls.innerHTML = `
     <button id="prevFrame">⏮️</button>
@@ -19,6 +19,12 @@ export function initUI(timeline, onFrameChange) {
     <button id="exportAnim">💾 Export</button>
     <input type="file" id="importAnim" style="display:none" />
     <button id="importAnimBtn">📂 Import</button>
+    <label style="margin-left:20px;">Rotation
+      <input type="range" id="pantinRotate" min="-180" max="180" value="0">
+    </label>
+    <label style="margin-left:10px;">Taille
+      <input type="range" id="pantinScale" min="0.1" max="3" step="0.1" value="1">
+    </label>
   `;
 
   // Référence rapide
@@ -112,6 +118,16 @@ export function initUI(timeline, onFrameChange) {
     reader.readAsText(file);
     e.target.value = ''; // Reset input
   };
+
+  // Sliders pour rotation et taille du pantin
+  const rotateInput = document.getElementById('pantinRotate');
+  const scaleInput = document.getElementById('pantinScale');
+  if (rotateInput && pantinControls) {
+    rotateInput.oninput = (e) => pantinControls.setRotate(parseFloat(e.target.value));
+  }
+  if (scaleInput && pantinControls) {
+    scaleInput.oninput = (e) => pantinControls.setScale(parseFloat(e.target.value));
+  }
 
   // Initial affichage
   updateFrameInfo();


### PR DESCRIPTION
## Summary
- expand the SVG container so translations remain visible
- rework global interactions to only use an invisible drag handle
- expose `setRotate` and `setScale` functions
- add rotation/scale sliders to the UI
- document the new controls

## Testing
- `node -e "import('./src/main.js').then(()=>console.log('ok')).catch(err=>console.error('err',err))"`

------
https://chatgpt.com/codex/tasks/task_e_688d29e1a79c832b865e23a82a7fa590