### PR TITLE
Improve SVG loading and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Ce projet permet d'animer un pantin SVG directement dans le navigateur. Il est c
 
 ## Fonctionnement general
 
-1. **index.html** charge le fichier SVG `manu.svg` ainsi que le script principal `src/main.js`.
+1. **index.html** contient un conteneur `#pantin` dans lequel `svgLoader.js` insère le fichier `manu.svg` puis charge le script principal `src/main.js`.
 2. **svgLoader.js** importe le SVG, reparent certains elements pour obtenir une structure coherente et calcule les points pivots utilises pour les rotations.
 3. **timeline.js** gere une liste de *frames*. Chaque frame enregistre la rotation de chaque membre du pantin. Il est possible d'ajouter, supprimer ou lire les frames.
-4. **interactions.js** permet de faire tourner chaque membre a la souris et ajoute des interactions globales (deplacement, rotation et redimensionnement du pantin complet).
-5. **ui.js** affiche une petite interface (boutons de lecture, ajout de frame, import/export...) et synchronise ces actions avec la timeline.
+4. **interactions.js** permet de faire tourner chaque membre à la souris et gère le déplacement du pantin. La rotation et la mise à l'échelle se font désormais via des sliders dans l'UI.
+5. **ui.js** affiche une interface avec boutons (lecture, ajout de frame, import/export) ainsi que deux sliders pour la rotation et l'échelle. Toutes ces actions sont synchronisées avec la timeline.
 
 Lors du chargement, `main.js` instancie la timeline, branche les interactions et applique la frame courante sur le SVG. L'etat de l'animation est sauvegarde automatiquement dans `localStorage` apres chaque modification et recharge au demarrage si present.
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
     #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
     #frameInfo { margin: 0 14px; font-weight: bold; }
+    #theatre { width: 100%; height: 80vh; position: relative; }
+    #pantin svg { overflow: visible; }
   </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
@@ -17,7 +19,7 @@
 <body>
   <h1 style="text-align:center;">Pantin Animateur</h1>
   <div id="theatre">
-  <object id="pantin" data="manu.svg" type="image/svg+xml"></object>
+    <div id="pantin"></div>
   </div>
   <div id="controls"></div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { setupInteractions } from './interactions.js';
 import { setupPantinGlobalInteractions } from './interactions.js';
 import { initUI } from './ui.js';
 
-// ID de l'objet <object> dans index.html
+// ID du conteneur destiné à recevoir le SVG
 const OBJ_ID = "pantin";
 
 // Charge le SVG et initialise toute l'app
@@ -33,7 +33,7 @@ loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
       setRotation(el, angle, pivot);
     });
   }
-setupPantinGlobalInteractions(svgDoc, {
+const pantinCtrl = setupPantinGlobalInteractions(svgDoc, {
   rootGroupId: "manu_test",   // ton groupe racine
   grabId: "torse",             // id du torse pour le centre et le handle
   onChange: () => { /* callback pour undo/redo, sauvegarde, etc. */ }
@@ -49,7 +49,7 @@ setupPantinGlobalInteractions(svgDoc, {
   // --- 4. Branche l'UI ---
   initUI(timeline, () => {
     applyFrameToSVG(timeline.getCurrentFrame());
-  });
+  }, pantinCtrl);
 
   // --- 5. Première application ---
   applyFrameToSVG(timeline.getCurrentFrame());

--- a/src/svgLoader.js
+++ b/src/svgLoader.js
@@ -1,33 +1,33 @@
 // src/svgLoader.js
 
 /**
- * Charge le SVG via l'objet <object id="pantin"> et prépare :
+ * Charge le SVG dans l'élément cible et prépare :
  *  - memberList : liste des ids des groupes animables
  *  - pivots : objet { id: { x, y } } pour chaque membre (point pivot exact, pas centre bbox)
  *  - svgDoc : document SVG manipulable
  *  - joints : liste des [segment, pivot, extrémité]
  *
- * @param {string} objectId - l'id de l'objet HTML (ex: "pantin")
+ * @param {string} containerId - id de l'élément qui contiendra le SVG
+ * @param {string} url        - chemin du fichier SVG
  * @returns {Promise<{svgDoc, memberList, pivots, joints}>}
  */
-export function loadSVG(objectId = "pantin") {
+export function loadSVG(containerId = "pantin", url = "manu.svg") {
   return new Promise((resolve, reject) => {
-    const obj = document.getElementById(objectId);
-    if (!obj) return reject(new Error(`Objet #${objectId} introuvable`));
+    const container = document.getElementById(containerId);
+    if (!container) return reject(new Error(`Élément #${containerId} introuvable`));
 
-    // Si déjà chargé
-    if (obj.contentDocument && obj.contentDocument.documentElement) {
-      prepare(obj.contentDocument);
-      return;
-    }
-
-    obj.addEventListener("load", () => {
-      if (!obj.contentDocument) return reject(new Error("SVG non chargé"));
-      prepare(obj.contentDocument);
-    });
+    fetch(url)
+      .then(r => r.text())
+      .then(text => {
+        container.innerHTML = text;
+        const svgDoc = container.querySelector('svg');
+        if (!svgDoc) throw new Error('SVG introuvable');
+        prepare(svgDoc);
+      })
+      .catch(err => reject(err));
 
     function prepare(svgDoc) {
-      const root = svgDoc.documentElement;
+      const root = svgDoc;
 
       // -- Re-parenting comme dans ton code d'origine --
       [

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,8 +5,9 @@
  *
  * @param {Timeline} timeline - instance de Timeline
  * @param {Function} onFrameChange - callback appelée après chaque modif (ex: pour réappliquer la frame sur le SVG)
+ * @param {Object} pantinCtrl - objet retourné par setupPantinGlobalInteractions
  */
-export function initUI(timeline, onFrameChange) {
+export function initUI(timeline, onFrameChange, pantinCtrl) {
   const controls = document.getElementById('controls');
   controls.innerHTML = `
     <button id="prevFrame">⏮️</button>
@@ -19,6 +20,12 @@ export function initUI(timeline, onFrameChange) {
     <button id="exportAnim">💾 Export</button>
     <input type="file" id="importAnim" style="display:none" />
     <button id="importAnimBtn">📂 Import</button>
+    <label style="margin-left:10px;">Rotation
+      <input type="range" id="rotateSlider" min="-180" max="180" value="0" step="1">
+    </label>
+    <label>Échelle
+      <input type="range" id="scaleSlider" min="0.1" max="3" value="1" step="0.1">
+    </label>
   `;
 
   // Référence rapide
@@ -111,6 +118,13 @@ export function initUI(timeline, onFrameChange) {
     };
     reader.readAsText(file);
     e.target.value = ''; // Reset input
+  };
+
+  document.getElementById('rotateSlider').oninput = (e) => {
+    pantinCtrl.setRotation(parseFloat(e.target.value));
+  };
+  document.getElementById('scaleSlider').oninput = (e) => {
+    pantinCtrl.setScale(parseFloat(e.target.value));
   };
 
   // Initial affichage


### PR DESCRIPTION
## Summary
- load the mannequin SVG inline instead of via `<object>`
- tweak styles and container for larger workspace
- provide invisible drag handle and rotation/scale sliders
- expose simple control API from `setupPantinGlobalInteractions`
- update docs for new behaviour

## Testing
- `node --check src/svgLoader.js`
- `node --check src/interactions.js`
- `node --check src/main.js`
- `node --check src/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_688d29e1a79c832b865e23a82a7fa590