### PR TITLE
Implement slider based transform controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ce projet permet d'animer un pantin SVG directement dans le navigateur. Il est c
 1. **index.html** charge le fichier SVG `manu.svg` ainsi que le script principal `src/main.js`.
 2. **svgLoader.js** importe le SVG, reparent certains elements pour obtenir une structure coherente et calcule les points pivots utilises pour les rotations.
 3. **timeline.js** gere une liste de *frames*. Chaque frame enregistre la rotation de chaque membre du pantin. Il est possible d'ajouter, supprimer ou lire les frames.
-4. **interactions.js** permet de faire tourner chaque membre a la souris et ajoute des interactions globales (deplacement, rotation et redimensionnement du pantin complet).
+4. **interactions.js** permet de faire tourner chaque membre a la souris et ajoute un deplacement global du pantin. La rotation et la mise a l'echelle se reglent desormais via des sliders.
 5. **ui.js** affiche une petite interface (boutons de lecture, ajout de frame, import/export...) et synchronise ces actions avec la timeline.
 
 Lors du chargement, `main.js` instancie la timeline, branche les interactions et applique la frame courante sur le SVG. L'etat de l'animation est sauvegarde automatiquement dans `localStorage` apres chaque modification et recharge au demarrage si present.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
     #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
     #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
     #frameInfo { margin: 0 14px; font-weight: bold; }
+    #theatre { position: relative; width: 100vw; height: 70vh; overflow: visible; }
+    #pantin { width: 100%; height: 100%; overflow: visible; }
+    #transformControls { text-align: center; margin-top: 12px; }
+    #transformControls label { margin: 0 12px; }
+    #transformControls input[type=range] { width: 200px; }
   </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
@@ -20,6 +25,14 @@
   <object id="pantin" data="manu.svg" type="image/svg+xml"></object>
   </div>
   <div id="controls"></div>
+  <div id="transformControls">
+    <label>Rotation
+      <input id="rotateSlider" type="range" min="-180" max="180" value="0">
+    </label>
+    <label>Échelle
+      <input id="scaleSlider" type="range" min="0.1" max="3" step="0.1" value="1">
+    </label>
+  </div>
 
   <script type="module" src="./src/main.js"></script>
 </body>

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -79,27 +79,37 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
   if (!rootGroup.dataset.scale) rootGroup.dataset.scale = 1;
   if (!rootGroup.dataset.rotate) rootGroup.dataset.rotate = 0;
 
+  const rotateSlider = document.getElementById('rotateSlider');
+  const scaleSlider = document.getElementById('scaleSlider');
+  if (rotateSlider) rotateSlider.value = rootGroup.dataset.rotate;
+  if (scaleSlider) scaleSlider.value = rootGroup.dataset.scale;
+
   // Calcul du point de grab = centre du bounding box de grabId
   function getGrabCenter() {
     const box = grabEl.getBBox();
     return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
   }
 
-  // Etat du drag/resize/rotate
-  let mode = null; // "move" | "rotate" | "resize"
+  // État du déplacement du pantin
+  let mode = null; // "move"
   let startPt = null;
   let startTransform = {};
 
-  // Ajout de handles visuels (pour resize et rotate)
+  // Ajout d'un handle invisible pour le déplacement
   function createHandle(type, dx, dy, cursor, title) {
     const ns = "http://www.w3.org/2000/svg";
     const c = document.createElementNS(ns, "circle");
     const center = getGrabCenter();
     c.setAttribute("cx", center.x + dx);
     c.setAttribute("cy", center.y + dy);
-    c.setAttribute("r", 10);
-    c.setAttribute("fill", "#4cf");
-    c.setAttribute("opacity", 0.6);
+    c.setAttribute("r", 20);
+    if (type === "move") {
+      c.setAttribute("fill", "transparent");
+      c.setAttribute("stroke", "none");
+    } else {
+      c.setAttribute("fill", "#4cf");
+      c.setAttribute("opacity", 0.6);
+    }
     c.setAttribute("cursor", cursor);
     c.setAttribute("data-handle", type);
     c.setAttribute("title", title);
@@ -113,28 +123,35 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
     svgDoc.querySelectorAll('circle[data-handle]').forEach(h => h.remove());
   }
 
-  // Ajoute les handles (move, rotate, resize)
+  // Ajoute uniquement le handle de déplacement
   function addHandles() {
     removeHandles();
-    const center = getGrabCenter();
-    // Move handle (au centre du torse)
-    const moveHandle = createHandle("move", 0, 0, "move", "Déplacer le pantin");
-    // Rotate handle (ex : à droite du torse)
-    const rotateHandle = createHandle("rotate", 40, 0, "crosshair", "Tourner le pantin");
-    // Resize handle (ex : en haut du torse)
-    const resizeHandle = createHandle("resize", 0, -60, "ns-resize", "Redimensionner le pantin");
+    createHandle("move", 0, 0, "move", "Déplacer le pantin");
   }
 
   addHandles();
 
-  let handleActive = null;
+  if (rotateSlider) {
+    rotateSlider.addEventListener('input', () => {
+      rootGroup.dataset.rotate = rotateSlider.value;
+      applyTransform();
+      if (typeof onChange === 'function') onChange();
+    });
+  }
 
-  // Ecouteur de drag sur les handles
+  if (scaleSlider) {
+    scaleSlider.addEventListener('input', () => {
+      rootGroup.dataset.scale = scaleSlider.value;
+      applyTransform();
+      if (typeof onChange === 'function') onChange();
+    });
+  }
+
+  // Ecouteur de drag sur le handle de déplacement
   svgDoc.addEventListener('mousedown', function(e) {
     const t = e.target;
     if (!t.hasAttribute('data-handle')) return;
     mode = t.getAttribute('data-handle');
-    handleActive = t;
     startPt = getSVGCoords(svgDoc, e);
     // Stock la transform d'origine
     startTransform = {
@@ -153,24 +170,11 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
   function onMove(e) {
     if (!mode) return;
     const pt = getSVGCoords(svgDoc, e);
-    const center = getGrabCenter();
     if (mode === "move") {
       const dx = pt.x - startPt.x;
       const dy = pt.y - startPt.y;
       rootGroup.dataset.tx = startTransform.tx + dx;
       rootGroup.dataset.ty = startTransform.ty + dy;
-    }
-    else if (mode === "rotate") {
-      const a0 = Math.atan2(startPt.y - center.y, startPt.x - center.x);
-      const a1 = Math.atan2(pt.y - center.y, pt.x - center.x);
-      let delta = (a1 - a0) * 180 / Math.PI;
-      rootGroup.dataset.rotate = startTransform.rotate + delta;
-    }
-    else if (mode === "resize") {
-      const dist0 = Math.hypot(startPt.x - center.x, startPt.y - center.y);
-      const dist1 = Math.hypot(pt.x - center.x, pt.y - center.y);
-      const scale = dist1 / dist0;
-      rootGroup.dataset.scale = Math.max(0.1, startTransform.scale * scale);
     }
     applyTransform();
   }
@@ -178,7 +182,6 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
   function onUp(e) {
     if (mode) {
       mode = null;
-      handleActive = null;
       svgDoc.removeEventListener('mousemove', onMove);
       svgDoc.removeEventListener('mouseup', onUp);
       svgDoc.removeEventListener('mouseleave', onUp);

--- a/src/svgLoader.js
+++ b/src/svgLoader.js
@@ -28,6 +28,7 @@ export function loadSVG(objectId = "pantin") {
 
     function prepare(svgDoc) {
       const root = svgDoc.documentElement;
+      root.setAttribute('overflow', 'visible');
 
       // -- Re-parenting comme dans ton code d'origine --
       [


### PR DESCRIPTION
## Summary
- allow SVG to overflow the original canvas
- add CSS for stage and sliders
- insert rotation and scale sliders in HTML
- update `setupPantinGlobalInteractions` for slider events and cleaner handles
- document new interaction approach in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d29e1a79c832b865e23a82a7fa590