### PR TITLE
Improve puppet controls and load inline SVG

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
     #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
     #frameInfo { margin: 0 14px; font-weight: bold; }
+    .slider { width: 120px; vertical-align: middle; }
   </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
@@ -17,7 +18,7 @@
 <body>
   <h1 style="text-align:center;">Pantin Animateur</h1>
   <div id="theatre">
-  <object id="pantin" data="manu.svg" type="image/svg+xml"></object>
+    <div id="pantin" data-src="manu.svg"></div>
   </div>
   <div id="controls"></div>
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,7 +6,7 @@
  * @param {Timeline} timeline - instance de Timeline
  * @param {Function} onFrameChange - callback appelée après chaque modif (ex: pour réappliquer la frame sur le SVG)
  */
-export function initUI(timeline, onFrameChange) {
+export function initUI(timeline, onFrameChange, pantinCtrl = null) {
   const controls = document.getElementById('controls');
   controls.innerHTML = `
     <button id="prevFrame">⏮️</button>
@@ -19,6 +19,12 @@ export function initUI(timeline, onFrameChange) {
     <button id="exportAnim">💾 Export</button>
     <input type="file" id="importAnim" style="display:none" />
     <button id="importAnimBtn">📂 Import</button>
+    <label style="margin-left:20px;">Rotation
+      <input type="range" id="rotatePantin" class="slider" min="-180" max="180" value="0">
+    </label>
+    <label style="margin-left:10px;">Taille
+      <input type="range" id="scalePantin" class="slider" min="0.1" max="3" step="0.1" value="1">
+    </label>
   `;
 
   // Référence rapide
@@ -112,6 +118,21 @@ export function initUI(timeline, onFrameChange) {
     reader.readAsText(file);
     e.target.value = ''; // Reset input
   };
+
+  if (pantinCtrl) {
+    const rotInput = document.getElementById('rotatePantin');
+    const scaleInput = document.getElementById('scalePantin');
+    rotInput.oninput = (e) => {
+      pantinCtrl.setRotation(parseFloat(e.target.value));
+      onFrameChange();
+      save();
+    };
+    scaleInput.oninput = (e) => {
+      pantinCtrl.setScale(parseFloat(e.target.value));
+      onFrameChange();
+      save();
+    };
+  }
 
   // Initial affichage
   updateFrameInfo();


### PR DESCRIPTION
## Summary
- load `manu.svg` directly into the page instead of using `<object>`
- expose rotation and scale sliders for the puppet
- add dynamic pivot handling for limb rotations
- simplify global handle to a single hidden drag control

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d2f38e980832b994018ef1f972c80