### PR TITLE
Improve global puppet controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
     #controls { text-align: center; margin-bottom: 24px; }
     #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
     #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
+    #controls input[type=range] { vertical-align: middle; }
     #frameInfo { margin: 0 14px; font-weight: bold; }
+    #theatre { width: 800px; height: 600px; margin: auto; border: 1px solid #555; }
+    #theatre svg { width: 100%; height: 100%; }
   </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
@@ -17,7 +20,7 @@
 <body>
   <h1 style="text-align:center;">Pantin Animateur</h1>
   <div id="theatre">
-  <object id="pantin" data="manu.svg" type="image/svg+xml"></object>
+    <div id="pantinContainer"></div>
   </div>
   <div id="controls"></div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,11 @@ import { setupInteractions } from './interactions.js';
 import { setupPantinGlobalInteractions } from './interactions.js';
 import { initUI } from './ui.js';
 
-// ID de l'objet <object> dans index.html
-const OBJ_ID = "pantin";
+// ID du conteneur pour le SVG
+const OBJ_ID = "pantinContainer";
 
 // Charge le SVG et initialise toute l'app
-loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
+loadSVG(OBJ_ID, "manu.svg").then(({ svgDoc, memberList, pivots }) => {
 
   // --- 1. Instancie la timeline (1 frame initiale vierge) ---
   const timeline = new Timeline(memberList);
@@ -33,7 +33,7 @@ loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
       setRotation(el, angle, pivot);
     });
   }
-setupPantinGlobalInteractions(svgDoc, {
+const pantinControls = setupPantinGlobalInteractions(svgDoc, {
   rootGroupId: "manu_test",   // ton groupe racine
   grabId: "torse",             // id du torse pour le centre et le handle
   onChange: () => { /* callback pour undo/redo, sauvegarde, etc. */ }
@@ -49,7 +49,7 @@ setupPantinGlobalInteractions(svgDoc, {
   // --- 4. Branche l'UI ---
   initUI(timeline, () => {
     applyFrameToSVG(timeline.getCurrentFrame());
-  });
+  }, pantinControls);
 
   // --- 5. Première application ---
   applyFrameToSVG(timeline.getCurrentFrame());

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,7 +6,7 @@
  * @param {Timeline} timeline - instance de Timeline
  * @param {Function} onFrameChange - callback appelée après chaque modif (ex: pour réappliquer la frame sur le SVG)
  */
-export function initUI(timeline, onFrameChange) {
+export function initUI(timeline, onFrameChange, pantinControls) {
   const controls = document.getElementById('controls');
   controls.innerHTML = `
     <button id="prevFrame">⏮️</button>
@@ -19,6 +19,12 @@ export function initUI(timeline, onFrameChange) {
     <button id="exportAnim">💾 Export</button>
     <input type="file" id="importAnim" style="display:none" />
     <button id="importAnimBtn">📂 Import</button>
+    <label style="margin-left:20px;color:#ccc;">Rotation
+      <input id="globalRotate" type="range" min="-180" max="180" value="0" />
+    </label>
+    <label style="margin-left:10px;color:#ccc;">Scale
+      <input id="globalScale" type="range" min="0.1" max="3" step="0.1" value="1" />
+    </label>
   `;
 
   // Référence rapide
@@ -91,6 +97,16 @@ export function initUI(timeline, onFrameChange) {
     }, 100);
   };
 
+  // Sliders de rotation et scale du pantin
+  const rotSlider = document.getElementById('globalRotate');
+  const scaleSlider = document.getElementById('globalScale');
+  if (rotSlider && pantinControls) {
+    rotSlider.oninput = (e) => pantinControls.setRotation(parseFloat(e.target.value));
+  }
+  if (scaleSlider && pantinControls) {
+    scaleSlider.oninput = (e) => pantinControls.setScale(parseFloat(e.target.value));
+  }
+
   // Import JSON (bouton + file input caché)
   document.getElementById('importAnimBtn').onclick = () => {
     document.getElementById('importAnim').click();
@@ -115,5 +131,9 @@ export function initUI(timeline, onFrameChange) {
 
   // Initial affichage
   updateFrameInfo();
+  if (pantinControls) {
+    if (rotSlider) rotSlider.value = pantinControls.getRotation();
+    if (scaleSlider) scaleSlider.value = pantinControls.getScale();
+  }
 }
 


### PR DESCRIPTION
## Summary
- load the SVG directly into the page instead of using `<object>`
- provide invisible drag handle only
- add sliders for rotation and scale in the UI
- expose setters from global interaction helper

## Testing
- `node --check src/main.js`
- `node --check src/svgLoader.js`
- `node --check src/interactions.js`
- `node --check src/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_688d30406094832ba1facc0761a846dd