### PR TITLE
Enhance pantin manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Lors du chargement, `main.js` instancie la timeline, branche les interactions et
 
 - Lecture de l'animation a partir de la frame courante plutot que depuis le debut.
 - Sauvegarde automatique de la timeline dans `localStorage` et rechargement a l'ouverture de la page.
+- Ajout de curseurs pour faire tourner et redimensionner le pantin sans handles visibles.
+- Suppression du clip-path du SVG pour pouvoir deplacer le pantin sur toute la scene.
 
 ## Lancer le projet
 

--- a/index.html
+++ b/index.html
@@ -4,12 +4,14 @@
   <meta charset="UTF-8">
   <title>Pantin Animateur</title>
   <style>
-    body { font-family: sans-serif; background: #181818; color: #eaeaea; margin:0; }
-    #controls { text-align: center; margin-bottom: 24px; }
-    #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
-    #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
-    #frameInfo { margin: 0 14px; font-weight: bold; }
-  </style>
+      body { font-family: sans-serif; background: #181818; color: #eaeaea; margin:0; }
+      #controls { text-align: center; margin-bottom: 24px; }
+      #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
+      #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
+      #frameInfo { margin: 0 14px; font-weight: bold; }
+      #theatre { width: 100vw; height: 80vh; overflow: visible; position: relative; }
+      #pantin { width: 100%; height: 100%; display: block; overflow: visible; }
+    </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
 

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -97,9 +97,15 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
     const center = getGrabCenter();
     c.setAttribute("cx", center.x + dx);
     c.setAttribute("cy", center.y + dy);
-    c.setAttribute("r", 10);
-    c.setAttribute("fill", "#4cf");
-    c.setAttribute("opacity", 0.6);
+    c.setAttribute("r", 15);
+    if (type === "move") {
+      c.setAttribute("fill", "transparent");
+      c.setAttribute("stroke", "none");
+      c.setAttribute("opacity", 0);
+    } else {
+      c.setAttribute("fill", "#4cf");
+      c.setAttribute("opacity", 0.6);
+    }
     c.setAttribute("cursor", cursor);
     c.setAttribute("data-handle", type);
     c.setAttribute("title", title);
@@ -113,16 +119,10 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
     svgDoc.querySelectorAll('circle[data-handle]').forEach(h => h.remove());
   }
 
-  // Ajoute les handles (move, rotate, resize)
+  // Ajoute uniquement le handle de déplacement (invisible)
   function addHandles() {
     removeHandles();
-    const center = getGrabCenter();
-    // Move handle (au centre du torse)
-    const moveHandle = createHandle("move", 0, 0, "move", "Déplacer le pantin");
-    // Rotate handle (ex : à droite du torse)
-    const rotateHandle = createHandle("rotate", 40, 0, "crosshair", "Tourner le pantin");
-    // Resize handle (ex : en haut du torse)
-    const resizeHandle = createHandle("resize", 0, -60, "ns-resize", "Redimensionner le pantin");
+    createHandle("move", 0, 0, "move", "Déplacer le pantin").setAttribute("opacity", 0);
   }
 
   addHandles();
@@ -202,6 +202,18 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
     addHandles();
   }
 
+  function setScale(val) {
+    rootGroup.dataset.scale = parseFloat(val);
+    applyTransform();
+    if (typeof onChange === "function") onChange();
+  }
+
+  function setRotation(val) {
+    rootGroup.dataset.rotate = parseFloat(val);
+    applyTransform();
+    if (typeof onChange === "function") onChange();
+  }
+
   // Utilitaire pour coord écran → SVG
   function getSVGCoords(svgDoc, evt) {
     const pt = svgDoc.createElementNS("http://www.w3.org/2000/svg", "svg").createSVGPoint();
@@ -211,5 +223,7 @@ export function setupPantinGlobalInteractions(svgDoc, options) {
       ? pt.matrixTransform(svgDoc.documentElement.getScreenCTM().inverse())
       : { x: evt.clientX, y: evt.clientY };
   }
+
+  return { setScale, setRotation };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,7 @@ loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
       setRotation(el, angle, pivot);
     });
   }
-setupPantinGlobalInteractions(svgDoc, {
+const pantinCtrl = setupPantinGlobalInteractions(svgDoc, {
   rootGroupId: "manu_test",   // ton groupe racine
   grabId: "torse",             // id du torse pour le centre et le handle
   onChange: () => { /* callback pour undo/redo, sauvegarde, etc. */ }
@@ -47,7 +47,7 @@ setupPantinGlobalInteractions(svgDoc, {
   });
 
   // --- 4. Branche l'UI ---
-  initUI(timeline, () => {
+  initUI(timeline, pantinCtrl, () => {
     applyFrameToSVG(timeline.getCurrentFrame());
   });
 

--- a/src/svgLoader.js
+++ b/src/svgLoader.js
@@ -29,6 +29,13 @@ export function loadSVG(objectId = "pantin") {
     function prepare(svgDoc) {
       const root = svgDoc.documentElement;
 
+      // Permet de déplacer le pantin hors de son cadre
+      root.setAttribute('overflow', 'visible');
+      const g = svgDoc.getElementById('manu_test');
+      if (g) g.removeAttribute('clip-path');
+      const clip = svgDoc.querySelector('clipPath#clip0_1_2');
+      if (clip && clip.parentNode) clip.parentNode.removeChild(clip);
+
       // -- Re-parenting comme dans ton code d'origine --
       [
         ["main_droite", "avant_bras_droite"],

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,7 +6,7 @@
  * @param {Timeline} timeline - instance de Timeline
  * @param {Function} onFrameChange - callback appelée après chaque modif (ex: pour réappliquer la frame sur le SVG)
  */
-export function initUI(timeline, onFrameChange) {
+export function initUI(timeline, pantinCtrl, onFrameChange) {
   const controls = document.getElementById('controls');
   controls.innerHTML = `
     <button id="prevFrame">⏮️</button>
@@ -19,10 +19,26 @@ export function initUI(timeline, onFrameChange) {
     <button id="exportAnim">💾 Export</button>
     <input type="file" id="importAnim" style="display:none" />
     <button id="importAnimBtn">📂 Import</button>
+    <label style="margin-left:20px;">Rotation
+      <input id="rotateSlider" type="range" min="-180" max="180" value="0">
+    </label>
+    <label style="margin-left:10px;">Taille
+      <input id="scaleSlider" type="range" min="0.1" max="3" step="0.1" value="1">
+    </label>
   `;
 
   // Référence rapide
   const frameInfo = document.getElementById('frameInfo');
+  const rotateSlider = document.getElementById('rotateSlider');
+  const scaleSlider = document.getElementById('scaleSlider');
+
+  rotateSlider.oninput = (e) => {
+    if (pantinCtrl && pantinCtrl.setRotation) pantinCtrl.setRotation(parseFloat(e.target.value));
+  };
+
+  scaleSlider.oninput = (e) => {
+    if (pantinCtrl && pantinCtrl.setScale) pantinCtrl.setScale(parseFloat(e.target.value));
+  };
 
   // Update de l'affichage frame courante
   function updateFrameInfo() {


### PR DESCRIPTION
## Summary
- expose rotation/scale sliders in the UI
- hide drag handle and remove rotate/resize handles
- allow SVG to move outside its original clip
- add new CSS so the theatre fills the viewport

## Testing
- `npm test` *(fails: ENOENT because package.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d30406094832ba1facc0761a846dd