### PR TITLE
Handle pantin movement with sliders

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
     #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
     #frameInfo { margin: 0 14px; font-weight: bold; }
+    #controls input[type=range] { vertical-align: middle; }
   </style>
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
@@ -17,7 +18,7 @@
 <body>
   <h1 style="text-align:center;">Pantin Animateur</h1>
   <div id="theatre">
-  <object id="pantin" data="manu.svg" type="image/svg+xml"></object>
+    <div id="pantin" data-src="manu.svg"></div>
   </div>
   <div id="controls"></div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { setupInteractions } from './interactions.js';
 import { setupPantinGlobalInteractions } from './interactions.js';
 import { initUI } from './ui.js';
 
-// ID de l'objet <object> dans index.html
+// ID du conteneur dans index.html
 const OBJ_ID = "pantin";
 
 // Charge le SVG et initialise toute l'app
@@ -33,7 +33,7 @@ loadSVG(OBJ_ID).then(({ svgDoc, memberList, pivots }) => {
       setRotation(el, angle, pivot);
     });
   }
-setupPantinGlobalInteractions(svgDoc, {
+const pantinCtrl = setupPantinGlobalInteractions(svgDoc, {
   rootGroupId: "manu_test",   // ton groupe racine
   grabId: "torse",             // id du torse pour le centre et le handle
   onChange: () => { /* callback pour undo/redo, sauvegarde, etc. */ }
@@ -47,7 +47,7 @@ setupPantinGlobalInteractions(svgDoc, {
   });
 
   // --- 4. Branche l'UI ---
-  initUI(timeline, () => {
+  initUI(timeline, pantinCtrl, () => {
     applyFrameToSVG(timeline.getCurrentFrame());
   });
 

--- a/src/svgLoader.js
+++ b/src/svgLoader.js
@@ -1,33 +1,37 @@
 // src/svgLoader.js
 
 /**
- * Charge le SVG via l'objet <object id="pantin"> et prépare :
+ * Charge le SVG depuis un conteneur possédant un attribut data-src
+ * et prépare :
  *  - memberList : liste des ids des groupes animables
  *  - pivots : objet { id: { x, y } } pour chaque membre (point pivot exact, pas centre bbox)
  *  - svgDoc : document SVG manipulable
  *  - joints : liste des [segment, pivot, extrémité]
  *
- * @param {string} objectId - l'id de l'objet HTML (ex: "pantin")
+ * @param {string} containerId - id de l'élément contenant le SVG
  * @returns {Promise<{svgDoc, memberList, pivots, joints}>}
  */
-export function loadSVG(objectId = "pantin") {
+export function loadSVG(containerId = "pantin") {
   return new Promise((resolve, reject) => {
-    const obj = document.getElementById(objectId);
-    if (!obj) return reject(new Error(`Objet #${objectId} introuvable`));
+    const container = document.getElementById(containerId);
+    if (!container) return reject(new Error(`Élément #${containerId} introuvable`));
+    const src = container.getAttribute('data-src');
+    if (!src) return reject(new Error(`Attribut data-src manquant sur #${containerId}`));
 
-    // Si déjà chargé
-    if (obj.contentDocument && obj.contentDocument.documentElement) {
-      prepare(obj.contentDocument);
-      return;
-    }
-
-    obj.addEventListener("load", () => {
-      if (!obj.contentDocument) return reject(new Error("SVG non chargé"));
-      prepare(obj.contentDocument);
-    });
+    fetch(src)
+      .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); })
+      .then(text => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(text, 'image/svg+xml');
+        const svgEl = doc.documentElement;
+        svgEl.id = containerId;
+        container.replaceWith(svgEl);
+        prepare(svgEl);
+      })
+      .catch(err => reject(err));
 
     function prepare(svgDoc) {
-      const root = svgDoc.documentElement;
+      const root = svgDoc;
 
       // -- Re-parenting comme dans ton code d'origine --
       [

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,9 +4,10 @@
  * Initialise l’UI de contrôle de la timeline
  *
  * @param {Timeline} timeline - instance de Timeline
+ * @param {Object} pantinCtrl - controleur retourné par setupPantinGlobalInteractions
  * @param {Function} onFrameChange - callback appelée après chaque modif (ex: pour réappliquer la frame sur le SVG)
  */
-export function initUI(timeline, onFrameChange) {
+export function initUI(timeline, pantinCtrl, onFrameChange) {
   const controls = document.getElementById('controls');
   controls.innerHTML = `
     <button id="prevFrame">⏮️</button>
@@ -19,6 +20,12 @@ export function initUI(timeline, onFrameChange) {
     <button id="exportAnim">💾 Export</button>
     <input type="file" id="importAnim" style="display:none" />
     <button id="importAnimBtn">📂 Import</button>
+    <label style="margin-left:10px;">Rotation
+      <input id="rotateSlider" type="range" min="-180" max="180" value="0" />
+    </label>
+    <label style="margin-left:10px;">Taille
+      <input id="scaleSlider" type="range" min="0.1" max="3" step="0.1" value="1" />
+    </label>
   `;
 
   // Référence rapide
@@ -112,6 +119,15 @@ export function initUI(timeline, onFrameChange) {
     reader.readAsText(file);
     e.target.value = ''; // Reset input
   };
+
+  // Contrôles rotation et échelle du pantin
+  const state = pantinCtrl.getState();
+  const rotSlider = document.getElementById('rotateSlider');
+  const scaleSlider = document.getElementById('scaleSlider');
+  rotSlider.value = state.rotate;
+  scaleSlider.value = state.scale;
+  rotSlider.oninput = (e) => pantinCtrl.setRotation(parseFloat(e.target.value));
+  scaleSlider.oninput = (e) => pantinCtrl.setScale(parseFloat(e.target.value));
 
   // Initial affichage
   updateFrameInfo();


### PR DESCRIPTION
## Summary
- embed `manu.svg` inline instead of using `<object>` to avoid clipping
- simplify global interaction handles and expose API for scale/rotation
- add rotation and scale sliders to the controls UI
- adapt main logic to new API

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688d30406094832ba1facc0761a846dd