### PR TITLE
Preserve existing transforms when rotating limbs

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -205,5 +205,9 @@ function getLocalMousePoint(evt, parentElement) {
 }
 
 function setRotation(el, angleDeg, pivot) {
-  el.setAttribute('transform', `rotate(${angleDeg},${pivot.x},${pivot.y})`);
+  const base = (el.getAttribute('transform') || '')
+    .replace(/rotate\([^)]+\)/, '')
+    .trim();
+  const rotateStr = `rotate(${angleDeg},${pivot.x},${pivot.y})`;
+  el.setAttribute('transform', `${base} ${rotateStr}`.trim());
 }


### PR DESCRIPTION
## Summary
- retain any non-rotation transforms when updating limb rotation so other transforms (like translate/scale) aren't lost

## Testing
- `node --check src/interactions.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0fee7ff0832b828cfaae53c9acbd