### PR TITLE
Align member rotation with cursor

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -130,8 +130,6 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
     if (!pivotInParentCoords) return;
 
     let isRotating = false;
-    let baseAngle = 0;
-    let startMouseAngle = 0;
 
     el.style.cursor = "grab";
 
@@ -141,14 +139,6 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
       e.preventDefault();
       e.stopPropagation();
 
-      const localMousePoint = getLocalMousePoint(e, el.parentNode);
-      
-      baseAngle = parseFloat(el.dataset.rotate) || 0;
-      startMouseAngle = Math.atan2(
-        localMousePoint.y - pivotInParentCoords.y, 
-        localMousePoint.x - pivotInParentCoords.x
-      ) * (180 / Math.PI);
-      
       svgElement.addEventListener('mousemove', processRotation);
       svgElement.addEventListener('mouseup', stopRotation);
       svgElement.addEventListener('mouseleave', stopRotation);
@@ -156,24 +146,17 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
 
     const processRotation = (e) => {
       if (!isRotating) return;
-      
+
       const localMousePoint = getLocalMousePoint(e, el.parentNode);
 
-      const currentMouseAngle = Math.atan2(
-        localMousePoint.y - pivotInParentCoords.y, 
+      const angle = Math.atan2(
+        localMousePoint.y - pivotInParentCoords.y,
         localMousePoint.x - pivotInParentCoords.x
       ) * (180 / Math.PI);
 
-      let deltaAngle = currentMouseAngle - startMouseAngle;
-
-      if (deltaAngle > 180) deltaAngle -= 360;
-      if (deltaAngle < -180) deltaAngle += 360;
-
-      const newAngle = baseAngle + deltaAngle;
-
-      el.dataset.rotate = newAngle;
-      setRotation(el, newAngle, pivotInParentCoords);
-      timeline.updateMember(id, { rotate: newAngle });
+      el.dataset.rotate = angle;
+      setRotation(el, angle, pivotInParentCoords);
+      timeline.updateMember(id, { rotate: angle });
     };
 
     const stopRotation = () => {


### PR DESCRIPTION
## Summary
- compute limb rotation angle directly from cursor position
- ensure selected member rotation updates in real time to follow pointer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e132bfa08832bb2e87fe6737b7cd1