### PR TITLE
Fix limb rotation to follow cursor

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -205,5 +205,7 @@ function getLocalMousePoint(evt, parentElement) {
 }
 
 function setRotation(el, angleDeg, pivot) {
-  el.setAttribute('transform', `rotate(${angleDeg},${pivot.x},${pivot.y})`);
+  const base = (el.getAttribute('transform') || '').replace(/rotate\([^)]+\)/, '').trim();
+  const rotateStr = `rotate(${angleDeg},${pivot.x},${pivot.y})`;
+  el.setAttribute('transform', `${base} ${rotateStr}`.trim());
 }


### PR DESCRIPTION
## Summary
- preserve existing transforms when rotating limbs so pivoting limbs follow the mouse cursor

## Testing
- `node --check src/interactions.js`
- `node --check src/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688e132bfa08832bb2e87fe6737b7cd1