### PR TITLE
Fix limb rotation to track mouse continuously

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -130,8 +130,8 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
     if (!pivotInParentCoords) return;
 
     let isRotating = false;
-    let baseAngle = 0;
-    let startMouseAngle = 0;
+    let currentAngle = 0;
+    let lastMouseAngle = 0;
 
     el.style.cursor = "grab";
 
@@ -142,10 +142,10 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
       e.stopPropagation();
 
       const localMousePoint = getLocalMousePoint(e, el.parentNode);
-      
-      baseAngle = parseFloat(el.dataset.rotate) || 0;
-      startMouseAngle = Math.atan2(
-        localMousePoint.y - pivotInParentCoords.y, 
+
+      currentAngle = parseFloat(el.dataset.rotate) || 0;
+      lastMouseAngle = Math.atan2(
+        localMousePoint.y - pivotInParentCoords.y,
         localMousePoint.x - pivotInParentCoords.x
       ) * (180 / Math.PI);
       
@@ -159,21 +159,21 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
       
       const localMousePoint = getLocalMousePoint(e, el.parentNode);
 
-      const currentMouseAngle = Math.atan2(
-        localMousePoint.y - pivotInParentCoords.y, 
+      const mouseAngle = Math.atan2(
+        localMousePoint.y - pivotInParentCoords.y,
         localMousePoint.x - pivotInParentCoords.x
       ) * (180 / Math.PI);
 
-      let deltaAngle = currentMouseAngle - startMouseAngle;
-
+      let deltaAngle = mouseAngle - lastMouseAngle;
       if (deltaAngle > 180) deltaAngle -= 360;
       if (deltaAngle < -180) deltaAngle += 360;
 
-      const newAngle = baseAngle + deltaAngle;
+      currentAngle += deltaAngle;
+      lastMouseAngle = mouseAngle;
 
-      el.dataset.rotate = newAngle;
-      setRotation(el, newAngle, pivotInParentCoords);
-      timeline.updateMember(id, { rotate: newAngle });
+      el.dataset.rotate = currentAngle;
+      setRotation(el, currentAngle, pivotInParentCoords);
+      timeline.updateMember(id, { rotate: currentAngle });
     };
 
     const stopRotation = () => {


### PR DESCRIPTION
## Summary
- use incremental mouse angle to rotate limbs smoothly around pivot

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e16f61404832b8c2d7ad337f05ee8