### PR TITLE
Ensure limb rotation follows cursor

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -130,8 +130,8 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
     if (!pivotInParentCoords) return;
 
     let isRotating = false;
-    let baseAngle = 0;
-    let startMouseAngle = 0;
+    let currentAngle = 0;
+    let grabOffsetAngle = 0;
 
     el.style.cursor = "grab";
 
@@ -142,12 +142,13 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
       e.stopPropagation();
 
       const localMousePoint = getLocalMousePoint(e, el.parentNode);
-      
-      baseAngle = parseFloat(el.dataset.rotate) || 0;
-      startMouseAngle = Math.atan2(
-        localMousePoint.y - pivotInParentCoords.y, 
+
+      currentAngle = parseFloat(el.dataset.rotate) || 0;
+      const mouseAngle = Math.atan2(
+        localMousePoint.y - pivotInParentCoords.y,
         localMousePoint.x - pivotInParentCoords.x
       ) * (180 / Math.PI);
+      grabOffsetAngle = mouseAngle - currentAngle;
       
       svgElement.addEventListener('mousemove', processRotation);
       svgElement.addEventListener('mouseup', stopRotation);
@@ -159,21 +160,16 @@ export function setupInteractions(svgElement, memberList, pivots, timeline) {
       
       const localMousePoint = getLocalMousePoint(e, el.parentNode);
 
-      const currentMouseAngle = Math.atan2(
-        localMousePoint.y - pivotInParentCoords.y, 
+      const mouseAngle = Math.atan2(
+        localMousePoint.y - pivotInParentCoords.y,
         localMousePoint.x - pivotInParentCoords.x
       ) * (180 / Math.PI);
 
-      let deltaAngle = currentMouseAngle - startMouseAngle;
+      currentAngle = mouseAngle - grabOffsetAngle;
 
-      if (deltaAngle > 180) deltaAngle -= 360;
-      if (deltaAngle < -180) deltaAngle += 360;
-
-      const newAngle = baseAngle + deltaAngle;
-
-      el.dataset.rotate = newAngle;
-      setRotation(el, newAngle, pivotInParentCoords);
-      timeline.updateMember(id, { rotate: newAngle });
+      el.dataset.rotate = currentAngle;
+      setRotation(el, currentAngle, pivotInParentCoords);
+      timeline.updateMember(id, { rotate: currentAngle });
     };
 
     const stopRotation = () => {


### PR DESCRIPTION
## Summary
- compute mouse angle relative to pivot and store grab offset to keep limb anchored to cursor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e16f61404832b8c2d7ad337f05ee8