### PR TITLE
Modernize UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,28 +3,29 @@
 <head>
   <meta charset="UTF-8">
   <title>Pantin Animateur</title>
-  <style>
-    body { font-family: sans-serif; background: #181818; color: #eaeaea; margin:0; }
-    #controls { text-align: center; margin-bottom: 24px; }
-    #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
-    #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
-    #frameInfo { margin: 0 14px; font-weight: bold; }
-  </style>
+  <link rel="stylesheet" href="styles.css">
   <!-- Interact.js CDN obligatoire pour interactions.js -->
 <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
 
 </head>
 <body>
-  <div id="theatre" style="width: 100%; height: 70vh; overflow: hidden; touch-action: none;">
-    <!-- Le SVG sera injecté ici par JS -->
-  </div>
-  <div id="controls"></div>
-  <div id="pantin-controls" style="text-align: center; margin-top: 20px; padding: 10px; background: #2a2a2a;">
-      <label for="scale-slider">Scale:</label>
-      <input type="range" id="scale-slider" min="0.1" max="3" step="0.05" value="1">
-      <label for="rotate-slider">Rotate:</label>
-      <input type="range" id="rotate-slider" min="-180" max="180" step="1" value="0">
-  </div>
+  <header>
+    <h1>Pantin Animateur</h1>
+  </header>
+  <main>
+    <div id="theatre">
+      <!-- Le SVG sera injecté ici par JS -->
+    </div>
+  </main>
+  <footer>
+    <div id="controls"></div>
+    <div id="pantin-controls">
+        <label for="scale-slider">Scale:</label>
+        <input type="range" id="scale-slider" min="0.1" max="3" step="0.05" value="1">
+        <label for="rotate-slider">Rotate:</label>
+        <input type="range" id="rotate-slider" min="-180" max="180" step="1" value="0">
+    </div>
+  </footer>
 
   <script type="module" src="./src/main.js?v=2"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,80 @@
+:root {
+  --bg: #181818;
+  --fg: #eaeaea;
+  --accent-hover: #2c6;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header {
+  background: #202020;
+  padding: 10px 16px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+
+main {
+  flex: 1;
+  display: flex;
+}
+
+#theatre {
+  flex: 1;
+  overflow: hidden;
+  touch-action: none;
+}
+
+footer {
+  background: #202020;
+  box-shadow: 0 -2px 4px rgba(0,0,0,0.4);
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#controls {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+#controls button {
+  font-size: 1.1em;
+  padding: 8px 12px;
+  border: none;
+  border-radius: 6px;
+  background: #333;
+  color: var(--fg);
+  cursor: pointer;
+  transition: background .2s, color .2s;
+}
+
+#controls button:hover {
+  background: var(--accent-hover);
+  color: #000;
+}
+
+#frameInfo {
+  margin: 0 14px;
+  font-weight: bold;
+}
+
+#pantin-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+
+#pantin-controls input[type=range] {
+  width: 150px;
+}


### PR DESCRIPTION
## Summary
- Restructure index layout into header, main stage, and footer for a more app-like interface
- Add external stylesheet implementing flexbox layout and modern button styling

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e3f02c940832b8d3e9f5f306e35c6