### PR TITLE
Modernise UI with application-style layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,23 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <title>Pantin Animateur</title>
-  <style>
-    body { font-family: sans-serif; background: #181818; color: #eaeaea; margin:0; }
-    #controls { text-align: center; margin-bottom: 24px; }
-    #controls button { margin: 0 6px; font-size: 1.2em; padding: 7px 14px; border-radius: 5px; border: 1px solid #888; background: #333; color: #eee; cursor: pointer; }
-    #controls button:hover { background: #2c6; color: #222; border-color: #3a3; }
-    #frameInfo { margin: 0 14px; font-weight: bold; }
-  </style>
+  <link rel="stylesheet" href="./style.css">
   <!-- Interact.js CDN obligatoire pour interactions.js -->
-<script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
 
 </head>
 <body>
-  <div id="theatre" style="width: 100%; height: 70vh; overflow: hidden; touch-action: none;">
+  <header class="app-header">
+    <h1>Pantin Animateur</h1>
+    <div id="controls"></div>
+  </header>
+  <div id="theatre">
     <!-- Le SVG sera injecté ici par JS -->
   </div>
-  <div id="controls"></div>
-  <div id="pantin-controls" style="text-align: center; margin-top: 20px; padding: 10px; background: #2a2a2a;">
+  <div id="pantin-controls" class="panel">
       <label for="scale-slider">Scale:</label>
       <input type="range" id="scale-slider" min="0.1" max="3" step="0.05" value="1">
       <label for="rotate-slider">Rotate:</label>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,81 @@
+:root {
+  --bg: #1f1f1f;
+  --fg: #f5f5f5;
+  --panel: #2b2b2b;
+  --accent: #4caf50;
+  --accent-hover: #45a049;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  padding: 10px 20px;
+  background: var(--panel);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+
+.app-header h1 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+#controls {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+#controls button {
+  padding: 6px 12px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--panel);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+#controls button:hover {
+  background: var(--accent);
+  color: #000;
+}
+
+#frameInfo {
+  align-self: center;
+  font-weight: bold;
+  padding: 0 4px;
+}
+
+#theatre {
+  flex: 1;
+  overflow: hidden;
+  touch-action: none;
+}
+
+.panel {
+  background: var(--panel);
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.panel input[type=range] {
+  accent-color: var(--accent);
+}


### PR DESCRIPTION
## Summary
- Organize markup with a header and control panel to give the editor an application-like layout.
- Extract styles into a dedicated stylesheet with dark theme, flex layout and modern toolbar buttons.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e3f02c940832b8d3e9f5f306e35c6