### PR TITLE
refactor: optimize animation runtime and UI handlers

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -25,17 +25,18 @@ export function setupPantinGlobalInteractions(svgElement, options, timeline, onU
   let dragging = false;
   let startPt;
   grabEl.style.cursor = 'move';
-  grabEl.addEventListener('mousedown', e => {
-    debugLog("Global drag: mousedown");
+  grabEl.addEventListener('pointerdown', e => {
+    debugLog("Global drag: pointerdown");
     dragging = true;
     startPt = getSVGCoords(e);
     grabEl.style.cursor = 'grabbing';
+    grabEl.setPointerCapture(e.pointerId);
     e.preventDefault();
   });
 
-  svgElement.addEventListener('mousemove', e => {
+  svgElement.addEventListener('pointermove', e => {
     if (!dragging) return;
-    debugLog("Global drag: mousemove");
+    debugLog("Global drag: pointermove");
     const pt = getSVGCoords(e);
     const frame = timeline.getCurrentFrame();
     timeline.updateTransform({
@@ -46,15 +47,16 @@ export function setupPantinGlobalInteractions(svgElement, options, timeline, onU
     onUpdate();
   });
 
-  const endDrag = () => {
+  const endDrag = e => {
     if (!dragging) return;
-    debugLog("Global drag: mouseup/mouseleave");
+    debugLog("Global drag: pointerup/pointerleave");
     dragging = false;
     grabEl.style.cursor = 'move';
+    grabEl.releasePointerCapture && grabEl.releasePointerCapture(e.pointerId);
     onEnd();
   };
-  svgElement.addEventListener('mouseup', endDrag);
-  svgElement.addEventListener('mouseleave', endDrag);
+  svgElement.addEventListener('pointerup', endDrag);
+  svgElement.addEventListener('pointerleave', endDrag);
 }
 
 // --- Utilities ---
@@ -75,18 +77,7 @@ function getSVGCoords(evt) {
  */
 export function setupInteractions(svgElement, memberList, pivots, timeline, onUpdate, onEnd) {
   debugLog("setupInteractions (members) called.");
-  // Anatomical pivot and terminal mappings (IDs of <g> elements)
-  const pivotMap = {
-    tete: 'cou',
-    bras_gauche: 'epaule_gauche',
-    avant_bras_gauche: 'coude_gauche',
-    bras_droite: 'epaule_droite',
-    avant_bras_droite: 'coude_droite',
-    jambe_gauche: 'hanche_gauche',
-    tibia_gauche: 'genou_gauche',
-    jambe_droite: 'hanche_droite',
-    tibia_droite: 'genou_droite',
-  };
+  // Terminal mappings (IDs of end segments)
   const terminalMap = {
     avant_bras_droite: 'main_droite',
     avant_bras_gauche: 'main_gauche',
@@ -100,13 +91,12 @@ export function setupInteractions(svgElement, memberList, pivots, timeline, onUp
       console.warn(`Segment ${id} not found.`);
       return;
     }
-    const pivotEl = svgElement.getElementById(pivotMap[id] || id);
     const termEl = svgElement.getElementById(terminalMap[id] || id);
 
     let rotating = false;
     let baseOri = 0;
     let pivotScreen;
-    let pivotLocal;
+    const pivotLocal = pivots[id];
 
     seg.style.cursor = 'grab';
     seg.addEventListener('pointerdown', e => {
@@ -116,14 +106,10 @@ export function setupInteractions(svgElement, memberList, pivots, timeline, onUp
       seg.setPointerCapture(e.pointerId);
       seg.style.cursor = 'grabbing';
 
-      // compute pivot in viewBox coords
-      const pBox = pivotEl.getBBox();
-      pivotLocal = { x: pBox.x + pBox.width / 2, y: pBox.y + pBox.height / 2 };
-
       // compute pivot screen coords (includes global transform)
       const pPt = svgElement.createSVGPoint();
       pPt.x = pivotLocal.x; pPt.y = pivotLocal.y;
-      pivotScreen = pPt.matrixTransform(pivotEl.getScreenCTM());
+      pivotScreen = pPt.matrixTransform(seg.parentNode.getScreenCTM());
 
       // compute terminal screen coords
       const tBox = termEl.getBBox();

--- a/src/onionSkin.js
+++ b/src/onionSkin.js
@@ -85,11 +85,17 @@ export function renderOnionSkins(timeline, applyFrameToPantin) {
 function createGhost(frame, type, applyFrameToPantin) {
   if (!pantinRoot) return null;
   const ghost = pantinRoot.cloneNode(true);
-  ghost.id = ''; // Les clones ne doivent pas avoir le même ID
-  ghost.classList.add('onion-skin-ghost', `onion-skin-${type}`);
-  
-  // Applique les transformations de la frame cible à ce fantôme
+
+  // Applique les transformations de la frame cible à ce fantôme avant de retirer les IDs
   applyFrameToPantin(frame, ghost);
+
+  // Remove all IDs to avoid duplicates in the DOM
+  (function stripIds(el) {
+    el.removeAttribute('id');
+    Array.from(el.children).forEach(stripIds);
+  })(ghost);
+
+  ghost.classList.add('onion-skin-ghost', `onion-skin-${type}`);
 
   return ghost;
 }

--- a/src/svgLoader.js
+++ b/src/svgLoader.js
@@ -6,82 +6,79 @@
  * @param {string} targetId - ID de l'élément où injecter le SVG (ex: "theatre")
  * @returns {Promise<{svgElement, memberList, pivots}>}
  */
-export function loadSVG(url, targetId) {
-  return fetch(url)
-    .then(response => {
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      return response.text();
-    })
-    .then(svgText => {
-      const target = document.getElementById(targetId);
-      if (!target) throw new Error(`Element cible #${targetId} introuvable`);
+export async function loadSVG(url, targetId) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const svgText = await response.text();
 
-      target.innerHTML = svgText;
-      const svgElement = target.querySelector('svg');
-      if (!svgElement) throw new Error("Aucun élément <svg> trouvé dans le fichier chargé.");
+  const target = document.getElementById(targetId);
+  if (!target) throw new Error(`Element cible #${targetId} introuvable`);
 
-      svgElement.setAttribute('width', '100%');
-      svgElement.setAttribute('height', '100%');
-      svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+  target.innerHTML = svgText;
+  const svgElement = target.querySelector('svg');
+  if (!svgElement) throw new Error('Aucun élément <svg> trouvé dans le fichier chargé.');
 
-      [
-        ["main_droite", "avant_bras_droite"],
-        ["main_gauche", "avant_bras_gauche"],
-        ["pied_droite", "tibia_droite"],
-        ["pied_gauche", "tibia_gauche"],
-      ].forEach(([childId, parentId]) => {
-        const ch = svgElement.getElementById(childId);
-        const pr = svgElement.getElementById(parentId);
-        if (ch && pr && ch.parentNode !== pr) pr.appendChild(ch);
-      });
+  svgElement.setAttribute('width', '100%');
+  svgElement.setAttribute('height', '100%');
+  svgElement.setAttribute('preserveAspectRatio', 'xMidYMid meet');
 
-      const torso = svgElement.getElementById("torse");
-      ["tete", "bras_gauche", "bras_droite", "jambe_gauche", "jambe_droite"].forEach(id => {
-        const el = svgElement.getElementById(id);
-        if (el && torso && torso.parentNode) torso.parentNode.insertBefore(el, torso);
-      });
+  [
+    ["main_droite", "avant_bras_droite"],
+    ["main_gauche", "avant_bras_gauche"],
+    ["pied_droite", "tibia_droite"],
+    ["pied_gauche", "tibia_gauche"],
+  ].forEach(([childId, parentId]) => {
+    const ch = svgElement.getElementById(childId);
+    const pr = svgElement.getElementById(parentId);
+    if (ch && pr && ch.parentNode !== pr) pr.appendChild(ch);
+  });
 
-      const joints = [
-        ['avant_bras_droite','coude_droite'],
-        ['avant_bras_gauche','coude_gauche'],
-        ['tibia_droite','genou_droite'],
-        ['tibia_gauche','genou_gauche'],
-        ['bras_droite','epaule_droite'],
-        ['bras_gauche','epaule_gauche'],
-        ['jambe_droite','hanche_droite'],
-        ['jambe_gauche','hanche_gauche'],
-        ['tete','cou']
-      ];
+  const torso = svgElement.getElementById('torse');
+  ['tete', 'bras_gauche', 'bras_droite', 'jambe_gauche', 'jambe_droite'].forEach(id => {
+    const el = svgElement.getElementById(id);
+    if (el && torso && torso.parentNode) torso.parentNode.insertBefore(el, torso);
+  });
 
-      const memberList = Array.from(new Set(joints.map(([seg]) => seg)));
+  const joints = [
+    ['avant_bras_droite', 'coude_droite'],
+    ['avant_bras_gauche', 'coude_gauche'],
+    ['tibia_droite', 'genou_droite'],
+    ['tibia_gauche', 'genou_gauche'],
+    ['bras_droite', 'epaule_droite'],
+    ['bras_gauche', 'epaule_gauche'],
+    ['jambe_droite', 'hanche_droite'],
+    ['jambe_gauche', 'hanche_gauche'],
+    ['tete', 'cou'],
+  ];
 
-      const pivots = {};
-      joints.forEach(([segment, pivotId]) => {
-        const pivotEl = svgElement.getElementById(pivotId);
-        const segmentEl = svgElement.getElementById(segment);
-        if (!pivotEl || !segmentEl || !segmentEl.parentNode) return;
+  const memberList = Array.from(new Set(joints.map(([seg]) => seg)));
 
-        // Coordonnées globales du centre du pivot au chargement
-        const pivotRect = pivotEl.getBoundingClientRect();
-        const svgRect = svgElement.getBoundingClientRect();
-        const globalPivotPos = {
-            x: pivotRect.left + pivotRect.width / 2 - svgRect.left,
-            y: pivotRect.top + pivotRect.height / 2 - svgRect.top
-        };
+  const pivots = {};
+  joints.forEach(([segment, pivotId]) => {
+    const pivotEl = svgElement.getElementById(pivotId);
+    const segmentEl = svgElement.getElementById(segment);
+    if (!pivotEl || !segmentEl || !segmentEl.parentNode) return;
 
-        // Matrice pour passer du repère global au repère local du parent
-        const parentInverseCTM = segmentEl.parentNode.getCTM().inverse();
+    // Coordonnées globales du centre du pivot au chargement
+    const pivotRect = pivotEl.getBoundingClientRect();
+    const svgRect = svgElement.getBoundingClientRect();
+    const globalPivotPos = {
+      x: pivotRect.left + pivotRect.width / 2 - svgRect.left,
+      y: pivotRect.top + pivotRect.height / 2 - svgRect.top,
+    };
 
-        const point = svgElement.createSVGPoint();
-        point.x = globalPivotPos.x;
-        point.y = globalPivotPos.y;
+    // Matrice pour passer du repère global au repère local du parent
+    const parentInverseCTM = segmentEl.parentNode.getCTM().inverse();
 
-        // On stocke la coordonnée du pivot dans le repère de son parent
-        pivots[segment] = point.matrixTransform(parentInverseCTM);
-      });
+    const point = svgElement.createSVGPoint();
+    point.x = globalPivotPos.x;
+    point.y = globalPivotPos.y;
 
-      return { svgElement, memberList, pivots };
-    });
+    // On stocke la coordonnée du pivot dans le repère de son parent
+    pivots[segment] = point.matrixTransform(parentInverseCTM);
+  });
+
+  return { svgElement, memberList, pivots };
 }

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -48,9 +48,15 @@ export class Timeline {
   }
 
   addFrame(duplicate = true) {
-    let newFrame = duplicate
-      ? JSON.parse(JSON.stringify(this.getCurrentFrame()))
-      : this.createEmptyFrame();
+    let newFrame;
+    if (duplicate) {
+      const currentFrame = this.getCurrentFrame();
+      newFrame = typeof structuredClone === 'function'
+        ? structuredClone(currentFrame)
+        : JSON.parse(JSON.stringify(currentFrame));
+    } else {
+      newFrame = this.createEmptyFrame();
+    }
     this.frames.splice(this.current + 1, 0, newFrame);
     this.current++;
     return this.getCurrentFrame();

--- a/src/ui.js
+++ b/src/ui.js
@@ -12,6 +12,19 @@ export function initUI(timeline, onFrameChange, onSave) {
   const frameInfo = document.getElementById('frameInfo');
   const timelineSlider = document.getElementById('timeline-slider');
   const fpsInput = document.getElementById('fps-input');
+  const prevFrameBtn = document.getElementById('prevFrame');
+  const nextFrameBtn = document.getElementById('nextFrame');
+  const playBtn = document.getElementById('playAnim');
+  const stopBtn = document.getElementById('stopAnim');
+  const addFrameBtn = document.getElementById('addFrame');
+  const delFrameBtn = document.getElementById('delFrame');
+  const exportAnimBtn = document.getElementById('exportAnim');
+  const importAnimBtn = document.getElementById('importAnimBtn');
+  const importAnimInput = document.getElementById('importAnim');
+  const resetStorageBtn = document.getElementById('resetStorage');
+  const onionSkinToggle = document.getElementById('onion-skin-toggle');
+  const pastFramesInput = document.getElementById('past-frames');
+  const futureFramesInput = document.getElementById('future-frames');
 
   // --- Panneau Inspecteur Escamotable ---
   const appContainer = document.getElementById('app-container');
@@ -51,12 +64,21 @@ export function initUI(timeline, onFrameChange, onSave) {
   });
   timelineSlider.addEventListener('change', onSave);
 
-  document.getElementById('prevFrame').onclick = () => { debugLog("Prev frame button clicked."); timeline.prevFrame(); updateUI(); onSave(); };
-  document.getElementById('nextFrame').onclick = () => { debugLog("Next frame button clicked."); timeline.nextFrame(); updateUI(); onSave(); };
+  prevFrameBtn.addEventListener('click', () => {
+    debugLog('Prev frame button clicked.');
+    timeline.prevFrame();
+    updateUI();
+    onSave();
+  });
+  nextFrameBtn.addEventListener('click', () => {
+    debugLog('Next frame button clicked.');
+    timeline.nextFrame();
+    updateUI();
+    onSave();
+  });
 
-  document.getElementById('playAnim').onclick = () => {
-    debugLog("Play button clicked.");
-    const playBtn = document.getElementById('playAnim');
+  playBtn.addEventListener('click', () => {
+    debugLog('Play button clicked.');
     if (timeline.playing) return;
 
     playBtn.textContent = '⏸️';
@@ -76,27 +98,36 @@ export function initUI(timeline, onFrameChange, onSave) {
       },
       fps
     );
-  };
+  });
 
-  document.getElementById('stopAnim').onclick = () => {
-    debugLog("Stop button clicked.");
+  stopBtn.addEventListener('click', () => {
+    debugLog('Stop button clicked.');
     timeline.stop();
     timeline.setCurrentFrame(0);
-    document.getElementById('playAnim').textContent = '▶️';
+    playBtn.textContent = '▶️';
     updateUI();
     onSave();
-  };
+  });
 
   // Actions sur les frames
-  document.getElementById('addFrame').onclick = () => { debugLog("Add frame button clicked."); timeline.addFrame(); updateUI(); onSave(); };
-  document.getElementById('delFrame').onclick = () => {
-    debugLog("Delete frame button clicked.");
-    if (timeline.frames.length > 1) { timeline.deleteFrame(); updateUI(); onSave(); }
-  };
+  addFrameBtn.addEventListener('click', () => {
+    debugLog('Add frame button clicked.');
+    timeline.addFrame();
+    updateUI();
+    onSave();
+  });
+  delFrameBtn.addEventListener('click', () => {
+    debugLog('Delete frame button clicked.');
+    if (timeline.frames.length > 1) {
+      timeline.deleteFrame();
+      updateUI();
+      onSave();
+    }
+  });
 
   // Actions de l'application
-  document.getElementById('exportAnim').onclick = () => {
-    debugLog("Export button clicked.");
+  exportAnimBtn.addEventListener('click', () => {
+    debugLog('Export button clicked.');
     const blob = new Blob([timeline.exportJSON()], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -104,17 +135,17 @@ export function initUI(timeline, onFrameChange, onSave) {
     a.download = `animation-${Date.now()}.json`;
     a.click();
     URL.revokeObjectURL(url);
-  };
+  });
 
   // Le label "importAnimBtn" est déjà lié à l'input fichier via l'attribut "for".
   // Appeler programmatique `click()` déclenchait donc deux fois l'ouverture de la
   // boîte de dialogue. On se contente du comportement par défaut qui ne l'ouvre
   // qu'une seule fois tout en conservant le message de debug.
-  document.getElementById('importAnimBtn').onclick = () => {
-    debugLog("Import button clicked.");
-  };
-  document.getElementById('importAnim').onchange = e => {
-    debugLog("Import file selected.");
+  importAnimBtn.addEventListener('click', () => {
+    debugLog('Import button clicked.');
+  });
+  importAnimInput.addEventListener('change', e => {
+    debugLog('Import file selected.');
     const file = e.target.files[0];
     if (!file) return;
     const reader = new FileReader();
@@ -123,20 +154,22 @@ export function initUI(timeline, onFrameChange, onSave) {
         timeline.importJSON(evt.target.result);
         updateUI();
         onSave();
-      } catch (err) { alert(`Erreur d'importation : ${err.message}`); }
+      } catch (err) {
+        alert(`Erreur d'importation : ${err.message}`);
+      }
     };
     reader.readAsText(file);
     e.target.value = '';
-  };
+  });
 
-  document.getElementById('resetStorage').onclick = () => {
-    debugLog("Reset storage button clicked.");
-    if (confirm("Voulez-vous vraiment réinitialiser le projet ?\nCette action est irréversible.")) {
+  resetStorageBtn.addEventListener('click', () => {
+    debugLog('Reset storage button clicked.');
+    if (confirm('Voulez-vous vraiment réinitialiser le projet ?\nCette action est irréversible.')) {
       localStorage.removeItem('animation');
       localStorage.removeItem(inspectorStateKey);
       window.location.reload();
     }
-  };
+  });
 
   // --- Contrôles de l'inspecteur --- //
   const controls = {
@@ -165,10 +198,6 @@ export function initUI(timeline, onFrameChange, onSave) {
   }
 
   // --- Contrôles Onion Skin ---
-  const onionSkinToggle = document.getElementById('onion-skin-toggle');
-  const pastFramesInput = document.getElementById('past-frames');
-  const futureFramesInput = document.getElementById('future-frames');
-
   const updateOnionSkin = () => {
     debugLog("updateOnionSkin called.");
     updateOnionSkinSettings({


### PR DESCRIPTION
## Summary
- cache DOM references and pivot centers to avoid repeated lookups
- migrate to pointer events for better input support and use precomputed pivots
- clean onion-skin clones and refactor SVG loading and timeline duplication

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbbb884b0832babd1a7f20d2e072f