### PR TITLE
feat: add selectable scene objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,22 @@
           </div>
         </div>
       </div>
+      <div id="object-controls" role="region" aria-label="Objets">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-select">Bibliothèque</label>
+          <select id="object-select"></select>
+        </div>
+        <div class="control-group">
+          <input type="checkbox" id="object-behind">
+          <label for="object-behind">Derrière le pantin</label>
+        </div>
+        <div class="control-group">
+          <input type="checkbox" id="object-attach">
+          <label for="object-attach">Coller au pantin</label>
+        </div>
+        <button type="button" id="add-object-btn" aria-label="Ajouter un objet">Ajouter</button>
+      </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,0 +1,134 @@
+// src/objects.js
+
+import { debugLog } from './debug.js';
+
+/**
+ * Initialise la gestion des objets additionnels.
+ * Les objets sont chargés depuis le dossier assets/objets et peuvent
+ * être ajoutés dans la scène, sélectionnés et manipulés.
+ *
+ * @param {SVGSVGElement} svgElement - L'élément SVG principal.
+ * @param {SVGElement} pantinRoot - Groupe racine du pantin.
+ * @param {Object} selection - Gestionnaire de sélection depuis main.js.
+ * @param {Function} refreshUI - Fonction pour rafraîchir l'inspecteur.
+ */
+export function initObjects(svgElement, pantinRoot, selection, refreshUI) {
+  const directory = 'assets/objets/';
+  const selectEl = document.getElementById('object-select');
+  const addBtn = document.getElementById('add-object-btn');
+  const behindChk = document.getElementById('object-behind');
+  const attachChk = document.getElementById('object-attach');
+
+  if (!selectEl || !addBtn) {
+    debugLog('Object controls not found in DOM.');
+    return;
+  }
+
+  // Récupère la liste des fichiers via l'index généré par le serveur
+  async function populateList() {
+    try {
+      const res = await fetch(directory);
+      const txt = await res.text();
+      const regex = /href="([^\"]+\.(svg|png))"/g;
+      let m;
+      while ((m = regex.exec(txt)) !== null) {
+        const opt = document.createElement('option');
+        opt.value = m[1];
+        opt.textContent = m[1];
+        selectEl.appendChild(opt);
+      }
+    } catch (e) {
+      console.warn('Impossible de charger la liste des objets:', e);
+    }
+  }
+
+  function applyTransform(el) {
+    const t = el._transform;
+    el.setAttribute(
+      'transform',
+      `translate(${t.tx},${t.ty}) rotate(${t.rotate}) scale(${t.scale})`
+    );
+  }
+
+  function makeDraggable(el) {
+    let dragging = false;
+    let startPt;
+    const getCoords = evt => {
+      const pt = svgElement.createSVGPoint();
+      pt.x = evt.clientX;
+      pt.y = evt.clientY;
+      return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+    };
+
+    el.style.cursor = 'move';
+
+    const onMove = e => {
+      if (!dragging) return;
+      const pt = getCoords(e);
+      const t = el._transform;
+      t.tx += pt.x - startPt.x;
+      t.ty += pt.y - startPt.y;
+      startPt = pt;
+      applyTransform(el);
+    };
+
+    const endDrag = e => {
+      dragging = false;
+      svgElement.removeEventListener('pointermove', onMove);
+    };
+
+    el.addEventListener('pointerdown', e => {
+      dragging = true;
+      startPt = getCoords(e);
+      svgElement.addEventListener('pointermove', onMove);
+      e.stopPropagation();
+      selection.selectObject(el);
+      refreshUI();
+    });
+    svgElement.addEventListener('pointerup', endDrag);
+    svgElement.addEventListener('pointerleave', endDrag);
+  }
+
+  async function addObject() {
+    const name = selectEl.value;
+    if (!name) return;
+    let el;
+    try {
+      if (name.endsWith('.svg')) {
+        const res = await fetch(directory + name);
+        const txt = await res.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(txt, 'image/svg+xml');
+        el = doc.documentElement;
+      } else {
+        el = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+        el.setAttributeNS('http://www.w3.org/1999/xlink', 'href', directory + name);
+      }
+    } catch (e) {
+      console.error('Erreur chargement objet', e);
+      return;
+    }
+
+    el.classList.add('scene-object');
+    el.dataset.name = name;
+    el._transform = { tx: 0, ty: 0, scale: 1, rotate: 0 };
+    applyTransform(el);
+
+    makeDraggable(el);
+
+    if (attachChk.checked) {
+      if (behindChk.checked) pantinRoot.insertBefore(el, pantinRoot.firstChild);
+      else pantinRoot.appendChild(el);
+    } else {
+      if (behindChk.checked) svgElement.insertBefore(el, pantinRoot);
+      else svgElement.appendChild(el);
+    }
+
+    selection.selectObject(el);
+    refreshUI();
+  }
+
+  addBtn.addEventListener('click', addObject);
+  populateList();
+}
+

--- a/src/ui.js
+++ b/src/ui.js
@@ -7,7 +7,7 @@ import { debugLog } from './debug.js';
  * @param {Function} onFrameChange - Callback pour rafraîchir le SVG.
  * @param {Function} onSave - Callback pour sauvegarder l'état.
  */
-export function initUI(timeline, onFrameChange, onSave) {
+export function initUI(timeline, onFrameChange, onSave, selection) {
   debugLog("initUI called.");
   const frameInfo = document.getElementById('frameInfo');
   const timelineSlider = document.getElementById('timeline-slider');
@@ -25,6 +25,9 @@ export function initUI(timeline, onFrameChange, onSave) {
   const onionSkinToggle = document.getElementById('onion-skin-toggle');
   const pastFramesInput = document.getElementById('past-frames');
   const futureFramesInput = document.getElementById('future-frames');
+  const scaleValueEl = document.getElementById('scale-value');
+  const rotateValueEl = document.getElementById('rotate-value');
+  const selectedNameEl = document.getElementById('selected-element-name');
 
   // --- Panneau Inspecteur Escamotable ---
   const appContainer = document.getElementById('app-container');
@@ -51,7 +54,12 @@ export function initUI(timeline, onFrameChange, onSave) {
     timelineSlider.max = frameCount > 1 ? frameCount - 1 : 0;
     timelineSlider.value = currentIndex;
 
-    onFrameChange(); // Rafraîchit le SVG et les valeurs de l'inspecteur
+    const t = selection.getTransform();
+    scaleValueEl.textContent = t.scale.toFixed(2);
+    rotateValueEl.textContent = Math.round(t.rotate);
+    selectedNameEl.textContent = selection.getName();
+
+    onFrameChange(); // Rafraîchit le SVG
   }
 
   // --- Connexions des événements --- //
@@ -190,15 +198,14 @@ export function initUI(timeline, onFrameChange, onSave) {
 
   function updateTransform(key, delta) {
     debugLog(`updateTransform for ${key} by ${delta}.`);
-    const currentFrame = timeline.getCurrentFrame();
-    const currentValue = currentFrame.transform[key];
+    const currentValue = selection.getTransform()[key];
     let newValue = currentValue + delta;
     if (key === 'scale') {
       newValue = Math.min(Math.max(newValue, 0.1), 10);
     } else if (key === 'rotate') {
       newValue = ((newValue % 360) + 360) % 360;
     }
-    timeline.updateTransform({ [key]: newValue });
+    selection.updateTransform({ [key]: newValue });
     updateUI();
     onSave();
   }
@@ -222,4 +229,5 @@ export function initUI(timeline, onFrameChange, onSave) {
 
   // Premier affichage
   updateUI();
+  return { updateUI };
 }


### PR DESCRIPTION
## Summary
- add inspector controls to insert PNG/SVG objects
- allow selecting pantin or objects and adjust scale/rotation
- add object manager with drag, layering and pantin attachment

## Testing
- `node --check src/main.js`
- `node --check src/ui.js`
- `node --check src/objects.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ffd85538c832b8fa48faeb227e8d0