### PR TITLE
feat: support des objets de scène

### DIFF
--- a/assets/objets/manifest.json
+++ b/assets/objets/manifest.json
@@ -1,0 +1,5 @@
+[
+  "carre.svg",
+  "faucille.svg",
+  "marteau.svg"
+]

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
       <div id="selection-info">
         <label for="selected-element-name">Sélection</label>
         <output id="selected-element-name">Pantin</output>
-      </div>
-      <div id="pantin-controls">
+        </div>
+        <div id="pantin-controls">
         <div class="control-group">
           <label for="scale-value">Échelle</label>
           <div class="value-stepper">
@@ -33,8 +33,24 @@
             <button type="button" id="rotate-plus" aria-label="Augmenter la rotation">+</button>
           </div>
         </div>
-      </div>
-      <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
+        </div>
+        <div id="object-manager">
+          <h3>Objets</h3>
+          <div class="control-group">
+            <label for="object-select">Objet</label>
+            <select id="object-select"></select>
+          </div>
+          <div class="control-group">
+            <input type="checkbox" id="object-front" checked>
+            <label for="object-front">Devant le pantin</label>
+          </div>
+          <div class="control-group">
+            <input type="checkbox" id="object-attach">
+            <label for="object-attach">Coller au pantin</label>
+          </div>
+          <button type="button" id="add-object-btn" aria-label="Ajouter l'objet">Ajouter</button>
+        </div>
+        <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">
           <input type="checkbox" id="onion-skin-toggle">

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { Timeline } from './timeline.js';
 import { setupInteractions, setupPantinGlobalInteractions } from './interactions.js';
 import { initUI } from './ui.js';
 import { debugLog } from './debug.js';
+import { setSelection, getSelection } from './selection.js';
 import CONFIG from './config.js';
 
 const { SVG_URL, THEATRE_ID, PANTIN_ROOT_ID, GRAB_ID } = CONFIG;
@@ -18,6 +19,7 @@ async function main() {
     // Cache frequently accessed DOM elements
     const scaleValueEl = document.getElementById('scale-value');
     const rotateValueEl = document.getElementById('rotate-value');
+    const selectedNameEl = document.getElementById('selected-element-name');
 
     // Cache elements for transformations
     const pantinRootGroup = svgElement.querySelector(`#${PANTIN_ROOT_ID}`);
@@ -33,6 +35,90 @@ async function main() {
       if (el) memberElements[id] = el;
     });
     pantinRootGroup._memberMap = memberElements;
+
+    const objectElements = {};
+    const objectCenters = {};
+
+    setSelection({ type: 'pantin', id: null, element: pantinRootGroup });
+    selectedNameEl.textContent = 'Pantin';
+
+    async function loadObjectElement(src, id) {
+      if (src.endsWith('.svg')) {
+        const res = await fetch(src);
+        const txt = await res.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(txt, 'image/svg+xml');
+        const el = doc.documentElement;
+        el.setAttribute('id', id);
+        return el;
+      } else {
+        const el = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+        el.setAttribute('href', src);
+        el.setAttribute('id', id);
+        return el;
+      }
+    }
+
+    function addObjectToDOM(el, id, def) {
+      el.setAttribute('data-object', id);
+      if (def.attach) {
+        if (def.front) pantinRootGroup.appendChild(el); else pantinRootGroup.insertBefore(el, pantinRootGroup.firstChild);
+      } else {
+        if (def.front) svgElement.appendChild(el); else svgElement.insertBefore(el, pantinRootGroup);
+      }
+      const bbox = el.getBBox();
+      objectElements[id] = el;
+      objectCenters[id] = { x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height / 2 };
+      setupObjectInteraction(el, id);
+    }
+
+    async function createObject(id, def) {
+      const el = await loadObjectElement(`assets/objets/${def.src}`, id);
+      addObjectToDOM(el, id, def);
+    }
+
+    function getSVGCoords(evt) {
+      const pt = svgElement.createSVGPoint();
+      pt.x = evt.clientX;
+      pt.y = evt.clientY;
+      return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+    }
+
+    function setupObjectInteraction(el, id) {
+      let dragging = false;
+      let startPt;
+      el.style.cursor = 'move';
+      const onMove = e => {
+        if (!dragging) return;
+        const pt = getSVGCoords(e);
+        const state = timeline.getCurrentFrame().objects[id];
+        timeline.updateObject(id, {
+          tx: state.tx + (pt.x - startPt.x),
+          ty: state.ty + (pt.y - startPt.y),
+        });
+        startPt = pt;
+        onFrameChange();
+      };
+      const endDrag = e => {
+        if (!dragging) return;
+        dragging = false;
+        svgElement.removeEventListener('pointermove', onMove);
+        onSave();
+      };
+      const onPointerDown = e => {
+        e.stopPropagation();
+        setSelection({ type: 'object', id, element: el });
+        selectedNameEl.textContent = id;
+        onFrameChange();
+        dragging = true;
+        startPt = getSVGCoords(e);
+        el.setPointerCapture && el.setPointerCapture(e.pointerId);
+        svgElement.addEventListener('pointermove', onMove);
+      };
+      el.addEventListener('pointerdown', onPointerDown);
+      svgElement.addEventListener('pointerup', endDrag);
+      svgElement.addEventListener('pointerleave', endDrag);
+    }
 
     // Function to apply a frame to a given SVG element (main pantin or ghost)
     const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = targetRootGroup._memberMap || memberElements) => {
@@ -61,6 +147,9 @@ async function main() {
     if (savedData) {
       try {
         timeline.importJSON(savedData);
+        for (const [id, def] of Object.entries(timeline.objects)) {
+          await createObject(id, def);
+        }
         debugLog("Animation chargée depuis localStorage.");
       } catch (e) {
         console.warn("Impossible de charger l'animation sauvegardée:", e);
@@ -75,9 +164,26 @@ async function main() {
       // Apply to main pantin
       applyFrameToPantinElement(frame, pantinRootGroup);
 
-      // Update inspector values
-      scaleValueEl.textContent = frame.transform.scale.toFixed(2);
-      rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      // Apply to objects
+      Object.keys(objectElements).forEach(id => {
+        const objState = frame.objects[id];
+        if (!objState) return;
+        const ctr = objectCenters[id];
+        const el = objectElements[id];
+        el.setAttribute('transform', `translate(${objState.tx},${objState.ty}) rotate(${objState.rotate},${ctr.x},${ctr.y}) scale(${objState.scale})`);
+      });
+
+      const sel = getSelection();
+      if (sel.type === 'pantin') {
+        scaleValueEl.textContent = frame.transform.scale.toFixed(2);
+        rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      } else if (sel.type === 'object') {
+        const obj = frame.objects[sel.id];
+        if (obj) {
+          scaleValueEl.textContent = obj.scale.toFixed(2);
+          rotateValueEl.textContent = Math.round(obj.rotate);
+        }
+      }
 
       // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
@@ -96,8 +202,43 @@ async function main() {
     debugLog("Setting up global pantin interactions...");
     const teardownGlobal = setupPantinGlobalInteractions(svgElement, interactionOptions, timeline, onFrameChange, onSave);
 
+    const objectSelect = document.getElementById('object-select');
+    const addObjectBtn = document.getElementById('add-object-btn');
+    const frontChk = document.getElementById('object-front');
+    const attachChk = document.getElementById('object-attach');
+
+    fetch('assets/objets/manifest.json')
+      .then(r => r.json())
+      .then(list => {
+        list.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          opt.textContent = name;
+          objectSelect.appendChild(opt);
+        });
+      });
+
+    addObjectBtn.addEventListener('click', async () => {
+      const file = objectSelect.value;
+      if (!file) return;
+      const id = `obj_${Date.now()}`;
+      const def = { src: file, attach: attachChk.checked, front: frontChk.checked };
+      timeline.addObject(id, def);
+      await createObject(id, def);
+      setSelection({ type: 'object', id, element: objectElements[id] });
+      selectedNameEl.textContent = id;
+      onFrameChange();
+      onSave();
+    });
+
     debugLog("Initializing UI...");
     initUI(timeline, onFrameChange, onSave);
+
+    grabEl?.addEventListener('pointerdown', () => {
+      setSelection({ type: 'pantin', id: null, element: pantinRootGroup });
+      selectedNameEl.textContent = 'Pantin';
+      onFrameChange();
+    });
 
     window.addEventListener('beforeunload', () => {
       teardownMembers();

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,0 +1,9 @@
+export let currentSelection = { type: 'pantin', id: null, element: null };
+
+export function setSelection(sel) {
+  currentSelection = sel;
+}
+
+export function getSelection() {
+  return currentSelection;
+}


### PR DESCRIPTION
## Summary
- ajout d’un gestionnaire d’objets sélectionnables avec options d’attache et de profondeur
- sauvegarde des transformations d’objets dans la timeline et import automatique
- contrôles de l’inspecteur applicables au pantin ou à l’objet choisi

## Testing
- `npm test` *(échoue : Could not read package.json)*
- `node --check src/main.js`
- `node --check src/ui.js`
- `node --check src/timeline.js`
- `node --check src/selection.js`


------
https://chatgpt.com/codex/tasks/task_e_688ffd85538c832b8fa48faeb227e8d0