### PR TITLE
feat: allow adding selectable objects

### DIFF
--- a/assets/objets/manifest.json
+++ b/assets/objets/manifest.json
@@ -1,0 +1,5 @@
+[
+  "carre.svg",
+  "faucille.svg",
+  "marteau.svg"
+]

--- a/index.html
+++ b/index.html
@@ -12,11 +12,16 @@
   <div id="app-container" class="app-container">
     <aside id="inspector-panel" role="region" aria-label="Contrôles de l'inspecteur">
       <h3>Inspecteur</h3>
+      <div id="object-add">
+        <label for="object-select">Ajouter objet</label>
+        <select id="object-select"></select>
+        <button type="button" id="add-object">Ajouter</button>
+      </div>
       <div id="selection-info">
         <label for="selected-element-name">Sélection</label>
         <output id="selected-element-name">Pantin</output>
       </div>
-      <div id="pantin-controls">
+      <div id="transform-controls">
         <div class="control-group">
           <label for="scale-value">Échelle</label>
           <div class="value-stepper">
@@ -32,6 +37,15 @@
             <output id="rotate-value" for="rotate-minus rotate-plus">0</output>
             <button type="button" id="rotate-plus" aria-label="Augmenter la rotation">+</button>
           </div>
+        </div>
+      </div>
+      <div id="object-controls" hidden>
+        <div class="control-group">
+          <label><input type="checkbox" id="attach-object"> Coller au pantin</label>
+        </div>
+        <div class="control-group">
+          <button type="button" id="object-back">Derrière</button>
+          <button type="button" id="object-front">Devant</button>
         </div>
       </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,0 +1,157 @@
+const objects = [];
+let selected = null;
+let svgRoot, pantinRoot;
+let selectionCallbacks = {};
+
+function applyTransform(obj) {
+  obj.el.setAttribute('transform',
+    `translate(${obj.tx},${obj.ty}) rotate(${obj.rotate}) scale(${obj.scale})`);
+}
+
+function select(obj) {
+  selected = obj;
+  if (selectionCallbacks.onSelect) {
+    selectionCallbacks.onSelect(obj);
+  }
+}
+
+export function getSelectedObject() {
+  return selected;
+}
+
+export function updateSelectedTransform(key, delta) {
+  if (!selected) return;
+  if (key === 'scale') {
+    selected.scale = Math.min(Math.max(selected.scale + delta, 0.1), 10);
+  } else if (key === 'rotate') {
+    selected.rotate = ((selected.rotate + delta) % 360 + 360) % 360;
+  }
+  applyTransform(selected);
+  if (selectionCallbacks.onSelect) selectionCallbacks.onSelect(selected);
+}
+
+export function attachSelected(flag) {
+  if (!selected) return;
+  selected.attached = flag;
+  if (flag) {
+    pantinRoot.appendChild(selected.el);
+  } else {
+    svgRoot.appendChild(selected.el);
+  }
+  updateZ(selected.z || 'front');
+}
+
+export function updateZ(position) {
+  if (!selected) return;
+  selected.z = position;
+  if (selected.attached) {
+    if (position === 'front') {
+      pantinRoot.appendChild(selected.el);
+    } else {
+      pantinRoot.insertBefore(selected.el, pantinRoot.firstChild);
+    }
+  } else {
+    if (position === 'front') {
+      svgRoot.appendChild(selected.el);
+    } else {
+      svgRoot.insertBefore(selected.el, pantinRoot);
+    }
+  }
+}
+
+function createObject(file) {
+  const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  g.classList.add('scene-object');
+  const img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+  img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', `assets/objets/${file}`);
+  img.setAttribute('x', 0);
+  img.setAttribute('y', 0);
+  img.setAttribute('width', 100);
+  img.setAttribute('height', 100);
+  g.appendChild(img);
+  svgRoot.appendChild(g);
+
+  const obj = { el: g, name: file, tx: 0, ty: 0, scale: 1, rotate: 0, attached: false, z: 'front' };
+  objects.push(obj);
+
+  interact(g).draggable({
+    listeners: {
+      move (event) {
+        obj.tx += event.dx;
+        obj.ty += event.dy;
+        applyTransform(obj);
+      }
+    }
+  });
+
+  g.addEventListener('pointerdown', e => {
+    e.stopPropagation();
+    select(obj);
+  });
+
+  applyTransform(obj);
+  return obj;
+}
+
+export function initObjects(svgElement, pantinRootGroup, callbacks = {}) {
+  svgRoot = svgElement;
+  pantinRoot = pantinRootGroup;
+  selectionCallbacks = callbacks;
+
+  const selectEl = document.getElementById('object-select');
+  const addBtn = document.getElementById('add-object');
+
+  fetch('assets/objets/manifest.json')
+    .then(resp => resp.json())
+    .then(list => {
+      list.forEach(name => {
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = name;
+        selectEl.appendChild(opt);
+      });
+    }).catch(err => console.error('Manifest objets introuvable', err));
+
+  addBtn.addEventListener('click', () => {
+    const file = selectEl.value;
+    if (!file) return;
+    const obj = createObject(file);
+    select(obj);
+  });
+
+  svgElement.addEventListener('pointerdown', () => {
+    select(null);
+  });
+}
+
+export function exportObjects() {
+  return objects.map(o => ({
+    name: o.name,
+    tx: o.tx,
+    ty: o.ty,
+    scale: o.scale,
+    rotate: o.rotate,
+    attached: o.attached,
+    z: o.z,
+  }));
+}
+
+export function importObjects(list = []) {
+  list.forEach(data => {
+    const obj = createObject(data.name);
+    obj.tx = data.tx;
+    obj.ty = data.ty;
+    obj.scale = data.scale;
+    obj.rotate = data.rotate;
+    obj.attached = data.attached;
+    obj.z = data.z || 'front';
+    applyTransform(obj);
+    if (obj.attached) {
+      pantinRoot.appendChild(obj.el);
+    }
+    const prev = selected;
+    selected = obj;
+    updateZ(obj.z);
+    selected = prev;
+  });
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,6 @@
 import { updateOnionSkinSettings } from './onionSkin.js';
 import { debugLog } from './debug.js';
+import { getSelectedObject, updateSelectedTransform } from './objects.js';
 
 /**
  * Initialise l’UI et la connecte à la timeline.
@@ -190,15 +191,20 @@ export function initUI(timeline, onFrameChange, onSave) {
 
   function updateTransform(key, delta) {
     debugLog(`updateTransform for ${key} by ${delta}.`);
-    const currentFrame = timeline.getCurrentFrame();
-    const currentValue = currentFrame.transform[key];
-    let newValue = currentValue + delta;
-    if (key === 'scale') {
-      newValue = Math.min(Math.max(newValue, 0.1), 10);
-    } else if (key === 'rotate') {
-      newValue = ((newValue % 360) + 360) % 360;
+    const obj = getSelectedObject();
+    if (obj) {
+      updateSelectedTransform(key, delta);
+    } else {
+      const currentFrame = timeline.getCurrentFrame();
+      const currentValue = currentFrame.transform[key];
+      let newValue = currentValue + delta;
+      if (key === 'scale') {
+        newValue = Math.min(Math.max(newValue, 0.1), 10);
+      } else if (key === 'rotate') {
+        newValue = ((newValue % 360) + 360) % 360;
+      }
+      timeline.updateTransform({ [key]: newValue });
     }
-    timeline.updateTransform({ [key]: newValue });
     updateUI();
     onSave();
   }


### PR DESCRIPTION
## Summary
- add inspector UI to insert objects and control layering or attachment
- manage scene objects with dragging, scaling, rotation and persistence
- apply inspector transforms to selected objects

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ffd85538c832b8fa48faeb227e8d0