### PR TITLE
feat: add persistent objects with inspector controls

### DIFF
--- a/assets/objets/index.json
+++ b/assets/objets/index.json
@@ -1,0 +1,5 @@
+[
+  { "id": "carre", "src": "assets/objets/carre.svg" },
+  { "id": "faucille", "src": "assets/objets/faucille.svg" },
+  { "id": "marteau", "src": "assets/objets/marteau.svg" }
+]

--- a/index.html
+++ b/index.html
@@ -49,6 +49,28 @@
           <input type="number" id="future-frames" value="1" min="0" max="10">
         </div>
       </div>
+      <div id="object-panel" role="region" aria-label="Objets">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="new-object-select">Ajouter</label>
+          <select id="new-object-select"></select>
+          <button type="button" id="add-object-btn" aria-label="Ajouter un objet">➕</button>
+        </div>
+        <div class="control-group">
+          <label for="object-layer">Calque</label>
+          <select id="object-layer">
+            <option value="front">Devant</option>
+            <option value="back">Derrière</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label for="object-attach">Coller au membre</label>
+          <select id="object-attach">
+            <option value="">Aucun</option>
+          </select>
+        </div>
+        <button type="button" id="delete-object-btn">Supprimer l'objet</button>
+      </div>
     </aside>
     <main id="theatre" role="main"></main>
     <footer id="timeline-panel" role="contentinfo">

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -9,7 +9,7 @@ const pantinState = {
 };
 
 /** Setup global interactions: drag on torse, scale & rotate sliders. */
-export function setupPantinGlobalInteractions(svgElement, options, timeline, onUpdate, onEnd) {
+export function setupPantinGlobalInteractions(svgElement, options, timeline, onUpdate, onEnd, onSelect = () => {}) {
   debugLog("setupPantinGlobalInteractions called.");
   const { rootGroupId, grabId } = options;
   pantinState.svgElement = svgElement;
@@ -57,6 +57,7 @@ export function setupPantinGlobalInteractions(svgElement, options, timeline, onU
     grabEl.setPointerCapture(e.pointerId);
     svgElement.addEventListener('pointermove', onMove);
     e.preventDefault();
+    onSelect();
   };
 
   grabEl.addEventListener('pointerdown', onPointerDown);

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,0 +1,167 @@
+// src/objects.js
+import { debugLog } from './debug.js';
+
+/**
+ * Gestion des objets ajoutés à la scène.
+ * @param {SVGElement} svgElement
+ * @param {SVGElement} pantinRootGroup
+ * @param {Timeline} timeline
+ * @param {Object} ui - objet retourné par initUI (contient setSelection)
+ * @param {string[]} memberList
+ * @param {Function} onFrameChange
+ * @param {Function} onSave
+ */
+export function initObjectManager(svgElement, pantinRootGroup, timeline, ui, memberList, onFrameChange, onSave) {
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const layers = {};
+  const objectEls = {};
+
+  function createLayers() {
+    ['back', 'front'].forEach(name => {
+      let g = svgElement.getElementById(`objects-${name}`);
+      if (!g) {
+        g = document.createElementNS(svgNS, 'g');
+        g.setAttribute('id', `objects-${name}`);
+        if (name === 'back') {
+          pantinRootGroup.parentNode.insertBefore(g, pantinRootGroup);
+        } else {
+          pantinRootGroup.parentNode.insertBefore(g, pantinRootGroup.nextSibling);
+        }
+      }
+      layers[name] = g;
+    });
+  }
+
+  function getSVGCoords(evt) {
+    const pt = svgElement.createSVGPoint();
+    pt.x = evt.clientX;
+    pt.y = evt.clientY;
+    return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+  }
+
+  function refreshObject(id) {
+    const el = objectEls[id];
+    const tr = timeline.getObjectTransform(id);
+    if (!el || !tr) return;
+    el.setAttribute('transform', `translate(${tr.tx},${tr.ty}) rotate(${tr.rotate}) scale(${tr.scale})`);
+  }
+
+  function refreshAll() {
+    Object.keys(objectEls).forEach(refreshObject);
+  }
+
+  function setupDrag(el, id) {
+    let dragging = false;
+    let startPt;
+
+    const onMove = e => {
+      if (!dragging) return;
+      const pt = getSVGCoords(e);
+      const cur = timeline.getObjectTransform(id);
+      timeline.updateObjectTransform(id, {
+        tx: cur.tx + (pt.x - startPt.x),
+        ty: cur.ty + (pt.y - startPt.y),
+      });
+      startPt = pt;
+      refreshObject(id);
+    };
+
+    const endDrag = e => {
+      if (!dragging) return;
+      dragging = false;
+      svgElement.removeEventListener('pointermove', onMove);
+      el.releasePointerCapture && el.releasePointerCapture(e.pointerId);
+      onSave();
+    };
+
+    el.addEventListener('pointerdown', e => {
+      e.stopPropagation();
+      dragging = true;
+      startPt = getSVGCoords(e);
+      el.setPointerCapture && el.setPointerCapture(e.pointerId);
+      svgElement.addEventListener('pointermove', onMove);
+      ui.setSelection('object', id, id);
+    });
+    el.addEventListener('pointerup', endDrag);
+    el.addEventListener('pointerleave', endDrag);
+  }
+
+  function attachObject(id, memberId) {
+    const def = timeline.objectDefs[id];
+    if (!def) return;
+    def.attachedTo = memberId || null;
+    const el = objectEls[id];
+    if (!el) return;
+    if (memberId) {
+      const memberEl = pantinRootGroup.querySelector(`#${memberId}`);
+      if (memberEl) memberEl.appendChild(el);
+    } else {
+      layers[def.layer || 'front'].appendChild(el);
+    }
+    onFrameChange();
+  }
+
+  function setLayer(id, layer) {
+    const def = timeline.objectDefs[id];
+    if (!def) return;
+    def.layer = layer;
+    if (!def.attachedTo) {
+      layers[layer].appendChild(objectEls[id]);
+    }
+    onFrameChange();
+  }
+
+  function addObject(def) {
+    const id = def.id;
+    if (!id || objectEls[id]) return;
+    timeline.addObject(id, { src: def.src, attachedTo: null, layer: 'front' });
+    const el = document.createElementNS(svgNS, 'image');
+    el.setAttributeNS('http://www.w3.org/1999/xlink', 'href', def.src);
+    el.setAttribute('width', 100);
+    el.setAttribute('height', 100);
+    el.setAttribute('data-object-id', id);
+    el.style.cursor = 'move';
+    layers.front.appendChild(el);
+    objectEls[id] = el;
+    setupDrag(el, id);
+    refreshObject(id);
+    ui.setSelection('object', id, id);
+    onFrameChange();
+    onSave();
+  }
+
+  function removeObject(id) {
+    const el = objectEls[id];
+    if (el) el.remove();
+    delete objectEls[id];
+    timeline.removeObject(id);
+    ui.setSelection('pantin', null, 'Pantin');
+    onFrameChange();
+    onSave();
+  }
+
+  function importExisting() {
+    Object.entries(timeline.objectDefs).forEach(([id, def]) => {
+      const el = document.createElementNS(svgNS, 'image');
+      el.setAttributeNS('http://www.w3.org/1999/xlink', 'href', def.src);
+      el.setAttribute('width', 100);
+      el.setAttribute('height', 100);
+      el.setAttribute('data-object-id', id);
+      el.style.cursor = 'move';
+      objectEls[id] = el;
+      setupDrag(el, id);
+      if (def.attachedTo) {
+        const memberEl = pantinRootGroup.querySelector(`#${def.attachedTo}`);
+        memberEl && memberEl.appendChild(el);
+      } else {
+        layers[def.layer || 'front'].appendChild(el);
+      }
+      refreshObject(id);
+    });
+  }
+
+  createLayers();
+  importExisting();
+
+  return { addObject, refreshAll, attachObject, setLayer, removeObject };
+}

--- a/style.css
+++ b/style.css
@@ -194,3 +194,27 @@ button:hover, .button:hover {
   /* Example color for future frames */
   filter: hue-rotate(90deg) saturate(1.5); /* Greenish tint */
 }
+
+#object-panel .control-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#object-panel .control-group label {
+  flex: 0 0 80px;
+  margin-bottom: 0;
+}
+
+#object-panel .control-group select {
+  flex: 1;
+}
+
+#object-panel #add-object-btn {
+  flex: 0 0 auto;
+}
+
+#object-panel #delete-object-btn {
+  width: 100%;
+  margin-top: 8px;
+}


### PR DESCRIPTION
## Summary
- allow adding/removing custom objects with drag, rotation, scale and attachment to puppet limbs
- persist object definitions in timeline and expose controls in the inspector
- style inspector object panel for clearer workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689004e67fb4832bbcebd52938b3f601