### PR TITLE
feat: enable object management

### DIFF
--- a/assets/objets/manifest.json
+++ b/assets/objets/manifest.json
@@ -1,0 +1,5 @@
+[
+  { "name": "Carré", "file": "carre.svg" },
+  { "name": "Faucille", "file": "faucille.svg" },
+  { "name": "Marteau", "file": "marteau.svg" }
+]

--- a/index.html
+++ b/index.html
@@ -34,6 +34,23 @@
           </div>
         </div>
       </div>
+      <div id="object-controls">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-select">Bibliothèque</label>
+          <select id="object-select"></select>
+          <button type="button" id="add-object">Ajouter</button>
+        </div>
+        <div class="control-group">
+          <button type="button" id="bring-front">Devant</button>
+          <button type="button" id="send-back">Derrière</button>
+          <button type="button" id="delete-object">Supprimer</button>
+        </div>
+        <div class="control-group">
+          <label for="attach-select">Coller à</label>
+          <select id="attach-select"><option value="">Aucun</option></select>
+        </div>
+      </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">


### PR DESCRIPTION
## Summary
- allow timeline frames to store and update scene objects
- add inspector controls and library for adding/removing objects
- render selectable objects with drag, layering and attachment to puppet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689004e67fb4832bbcebd52938b3f601