### PR TITLE
feat: add scene object management

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,32 @@
           </div>
         </div>
       </div>
+      <div id="object-controls" role="region" aria-label="Contrôles des objets">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-file">Ajouter un objet</label>
+          <select id="object-file">
+            <option value="assets/objets/carre.svg">Carré</option>
+            <option value="assets/objets/faucille.svg">Faucille</option>
+            <option value="assets/objets/marteau.svg">Marteau</option>
+          </select>
+          <div class="value-stepper">
+            <button type="button" id="add-object-back" title="Ajouter derrière" aria-label="Ajouter derrière">⬇️</button>
+            <button type="button" id="add-object-front" title="Ajouter devant" aria-label="Ajouter devant">⬆️</button>
+          </div>
+        </div>
+        <div class="control-group">
+          <label for="attach-select">Coller à</label>
+          <select id="attach-select">
+            <option value="">Aucun</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <button type="button" id="layer-front" aria-label="Placer devant">Avant-plan</button>
+          <button type="button" id="layer-back" aria-label="Placer derrière">Arrière-plan</button>
+          <button type="button" id="delete-object" aria-label="Supprimer l'objet">Supprimer</button>
+        </div>
+      </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,0 +1,165 @@
+import { debugLog } from './debug.js';
+
+const NS = 'http://www.w3.org/2000/svg';
+
+export function initObjects(svgElement, pantinRootGroup, memberList, timeline, onFrameChange, onSave, onSelectionChange) {
+  debugLog('initObjects called');
+  const objectsFront = document.createElementNS(NS, 'g');
+  objectsFront.id = 'objects-front';
+  const objectsBack = document.createElementNS(NS, 'g');
+  objectsBack.id = 'objects-back';
+  const parent = pantinRootGroup.parentNode;
+  parent.insertBefore(objectsBack, pantinRootGroup);
+  parent.insertBefore(objectsFront, pantinRootGroup.nextSibling);
+
+  const objectMap = {};
+  let selectedId = null;
+
+  function getSVGCoords(evt) {
+    const pt = svgElement.createSVGPoint();
+    pt.x = evt.clientX;
+    pt.y = evt.clientY;
+    return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+  }
+
+  let selectionCallback = onSelectionChange;
+
+  function select(id) {
+    selectedId = id;
+    if (typeof selectionCallback === 'function') selectionCallback(id);
+  }
+
+  function applyFrame(frame) {
+    const objs = frame.objects || {};
+    Object.entries(objs).forEach(([id, obj]) => {
+      const el = objectMap[id];
+      if (!el) return;
+      if (obj.attachedTo) {
+        const memberEl = pantinRootGroup.querySelector(`#${obj.attachedTo}`);
+        if (memberEl && el.parentNode !== memberEl) memberEl.appendChild(el);
+      } else {
+        const layerParent = obj.layer === 'back' ? objectsBack : objectsFront;
+        if (el.parentNode !== layerParent) layerParent.appendChild(el);
+      }
+      el.setAttribute('transform', `translate(${obj.tx},${obj.ty}) rotate(${obj.rotate}) scale(${obj.scale})`);
+    });
+  }
+
+  function setupDrag(el, id) {
+    let dragging = false;
+    let startPt;
+    el.style.cursor = 'move';
+
+    const onMove = e => {
+      if (!dragging) return;
+      const pt = getSVGCoords(e);
+      const obj = timeline.getCurrentFrame().objects[id];
+      timeline.updateObject(id, {
+        tx: obj.tx + (pt.x - startPt.x),
+        ty: obj.ty + (pt.y - startPt.y),
+      });
+      startPt = pt;
+      onFrameChange();
+    };
+
+    const endDrag = e => {
+      if (!dragging) return;
+      dragging = false;
+      el.style.cursor = 'move';
+      svgElement.removeEventListener('pointermove', onMove);
+      onSave();
+    };
+
+    const onPointerDown = e => {
+      e.stopPropagation();
+      select(id);
+      dragging = true;
+      startPt = getSVGCoords(e);
+      el.style.cursor = 'grabbing';
+      svgElement.addEventListener('pointermove', onMove);
+      svgElement.addEventListener('pointerup', endDrag, { once: true });
+      svgElement.addEventListener('pointerleave', endDrag, { once: true });
+    };
+
+    el.addEventListener('pointerdown', onPointerDown);
+  }
+
+  function createDOMForObject(id, src, layer) {
+    const img = new Image();
+    img.onload = () => {
+      const g = document.createElementNS(NS, 'g');
+      g.setAttribute('data-object-id', id);
+      const imageEl = document.createElementNS(NS, 'image');
+      imageEl.setAttributeNS('http://www.w3.org/1999/xlink', 'href', src);
+      imageEl.setAttribute('width', img.width);
+      imageEl.setAttribute('height', img.height);
+      imageEl.setAttribute('x', -img.width / 2);
+      imageEl.setAttribute('y', -img.height / 2);
+      g.appendChild(imageEl);
+      const layerParent = layer === 'back' ? objectsBack : objectsFront;
+      layerParent.appendChild(g);
+      objectMap[id] = g;
+      setupDrag(g, id);
+      onFrameChange();
+    };
+    img.src = src;
+  }
+
+  function addObject(src, layer = 'front') {
+    const id = `obj-${Date.now()}`;
+    timeline.addObject(id, { src, layer });
+    createDOMForObject(id, src, layer);
+    select(id);
+    onSave();
+  }
+
+  // load existing objects from timeline
+  const initialObjects = timeline.getCurrentFrame().objects;
+  Object.entries(initialObjects).forEach(([id, obj]) => {
+    createDOMForObject(id, obj.src, obj.layer);
+  });
+
+  function deleteSelected() {
+    if (!selectedId) return;
+    const el = objectMap[selectedId];
+    if (el) el.remove();
+    timeline.removeObject(selectedId);
+    delete objectMap[selectedId];
+    select(null);
+    onFrameChange();
+    onSave();
+  }
+
+  function attachSelected(memberId) {
+    if (!selectedId) return;
+    timeline.updateObject(selectedId, { attachedTo: memberId || null });
+    onFrameChange();
+    onSave();
+  }
+
+  function setLayer(layer) {
+    if (!selectedId) return;
+    timeline.updateObject(selectedId, { layer });
+    onFrameChange();
+    onSave();
+  }
+
+  svgElement.addEventListener('pointerdown', e => {
+    if (e.target === svgElement) {
+      select(null);
+      onFrameChange();
+    }
+  });
+
+  return {
+    addObject,
+    deleteSelected,
+    attachSelected,
+    setLayer,
+    applyFrame,
+    getSelectedId: () => selectedId,
+    getObjectData: id => timeline.getCurrentFrame().objects[id],
+    clearSelection: () => select(null),
+    setSelectionCallback: cb => { selectionCallback = cb; },
+  };
+}

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -4,7 +4,8 @@
  * Gestion de la timeline d'animation (frames)
  * Une frame = {
  *   transform: { tx, ty, scale, rotate },
- *   members: { segmentId: { rotate: angleDeg }, ... }
+ *   members: { segmentId: { rotate: angleDeg }, ... },
+ *   objects: { objectId: { tx, ty, scale, rotate, src, layer, attachedTo } }
  * }
  */
 
@@ -23,6 +24,7 @@ export class Timeline {
     return {
       transform: { tx: 0, ty: 0, scale: 1, rotate: 0 },
       members,
+      objects: {},
     };
   }
 
@@ -45,6 +47,33 @@ export class Timeline {
   updateTransform(values) {
     const frame = this.getCurrentFrame();
     frame.transform = { ...frame.transform, ...values };
+  }
+
+  addObject(id, data) {
+    this.frames.forEach(f => {
+      f.objects[id] = {
+        tx: 0,
+        ty: 0,
+        scale: 1,
+        rotate: 0,
+        layer: 'front',
+        attachedTo: null,
+        src: '',
+        ...data,
+      };
+    });
+  }
+
+  updateObject(id, values) {
+    const frame = this.getCurrentFrame();
+    if (!frame.objects[id]) return;
+    frame.objects[id] = { ...frame.objects[id], ...values };
+  }
+
+  removeObject(id) {
+    this.frames.forEach(f => {
+      delete f.objects[id];
+    });
   }
 
   addFrame(duplicate = true) {
@@ -128,7 +157,10 @@ export class Timeline {
 
       // Rétro-compatibilité : convertir l'ancien format
       const migratedFrames = arr.map(f => {
-        if (f.members && f.transform) return f; // Déjà au bon format
+        if (f.members && f.transform) {
+          if (!f.objects) f.objects = {};
+          return f; // Déjà au bon format
+        }
         return this._migrateOldFrame(f);
       });
 


### PR DESCRIPTION
## Summary
- allow adding image objects, layer them front or back, and glue them to puppet limbs
- persist object transforms across frames and expose controls in the inspector
- expose object transform controls and deletion inside revised UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/objects.js && node --check src/main.js && node --check src/ui.js && node --check src/timeline.js`


------
https://chatgpt.com/codex/tasks/task_e_689004e67fb4832bbcebd52938b3f601