### PR TITLE
feat: add object management to scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,34 @@
           <input type="number" id="future-frames" value="1" min="0" max="10">
         </div>
       </div>
+      <div id="object-controls">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-select">Ajouter</label>
+          <select id="object-select">
+            <option value="assets/objets/carre.svg">Carré</option>
+            <option value="assets/objets/faucille.svg">Faucille</option>
+            <option value="assets/objets/marteau.svg">Marteau</option>
+          </select>
+          <button type="button" id="add-object-btn">➕</button>
+        </div>
+        <div class="control-group">
+          <button type="button" id="delete-object-btn" disabled>Supprimer</button>
+        </div>
+        <div class="control-group">
+          <label for="object-layer-select">Calque</label>
+          <select id="object-layer-select">
+            <option value="front">Devant</option>
+            <option value="back">Derrière</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label for="attach-select">Coller à</label>
+          <select id="attach-select">
+            <option value="">Aucun</option>
+          </select>
+        </div>
+      </div>
     </aside>
     <main id="theatre" role="main"></main>
     <footer id="timeline-panel" role="contentinfo">

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { setupInteractions, setupPantinGlobalInteractions } from './interactions
 import { initUI } from './ui.js';
 import { debugLog } from './debug.js';
 import CONFIG from './config.js';
+import { appState } from './state.js';
 
 const { SVG_URL, THEATRE_ID, PANTIN_ROOT_ID, GRAB_ID } = CONFIG;
 
@@ -33,6 +34,145 @@ async function main() {
       if (el) memberElements[id] = el;
     });
     pantinRootGroup._memberMap = memberElements;
+
+    // Object layers
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const objectsBackGroup = document.createElementNS(SVG_NS, 'g');
+    objectsBackGroup.id = 'objects-back';
+    pantinRootGroup.insertBefore(objectsBackGroup, pantinRootGroup.firstChild);
+    const objectsFrontGroup = document.createElementNS(SVG_NS, 'g');
+    objectsFrontGroup.id = 'objects-front';
+    pantinRootGroup.appendChild(objectsFrontGroup);
+    const objectElements = new Map();
+
+    function renderObjects(frame) {
+      frame.objects.forEach(obj => {
+        const el = objectElements.get(obj.id);
+        if (!el) return;
+        let t = '';
+        if (obj.attachedTo) {
+          const pivot = pivots[obj.attachedTo];
+          const ang = frame.members[obj.attachedTo]?.rotate || 0;
+          t = `rotate(${ang},${pivot.x},${pivot.y}) translate(${obj.tx},${obj.ty}) rotate(${obj.rotate}) scale(${obj.scale})`;
+        } else {
+          t = `translate(${obj.tx},${obj.ty}) rotate(${obj.rotate}) scale(${obj.scale})`;
+        }
+        el.setAttribute('transform', t);
+      });
+    }
+
+    function selectPantin() {
+      appState.selected = { type: 'pantin', id: null };
+      document.dispatchEvent(new CustomEvent('selection-changed'));
+    }
+
+    function selectObject(id) {
+      appState.selected = { type: 'object', id };
+      document.dispatchEvent(new CustomEvent('selection-changed'));
+    }
+
+    svgElement.addEventListener('pointerdown', () => selectPantin());
+
+    function getSVGCoords(evt) {
+      const pt = svgElement.createSVGPoint();
+      pt.x = evt.clientX;
+      pt.y = evt.clientY;
+      return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+    }
+
+    function addObject(href, layer = 'front') {
+      const id = `obj_${Date.now()}`;
+      const g = document.createElementNS(SVG_NS, 'g');
+      g.dataset.objId = id;
+      const img = document.createElementNS(SVG_NS, 'image');
+      img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', href);
+      img.setAttribute('width', 100);
+      img.setAttribute('height', 100);
+      img.setAttribute('x', -50);
+      img.setAttribute('y', -50);
+      g.appendChild(img);
+      if (layer === 'front') objectsFrontGroup.appendChild(g); else objectsBackGroup.appendChild(g);
+      objectElements.set(id, g);
+
+      let dragging = false;
+      let startPt;
+      const onMove = e => {
+        if (!dragging) return;
+        const pt = getSVGCoords(e);
+        const dx = pt.x - startPt.x;
+        const dy = pt.y - startPt.y;
+        const frame = timeline.getCurrentFrame();
+        const obj = frame.objects.find(o => o.id === id);
+        timeline.updateObject(id, { tx: obj.tx + dx, ty: obj.ty + dy });
+        startPt = pt;
+        renderObjects(frame);
+      };
+      const endDrag = e => {
+        if (!dragging) return;
+        dragging = false;
+        g.releasePointerCapture && g.releasePointerCapture(e.pointerId);
+        svgElement.removeEventListener('pointermove', onMove);
+        onSave();
+      };
+      g.addEventListener('pointerdown', e => {
+        e.stopPropagation();
+        dragging = true;
+        startPt = getSVGCoords(e);
+        g.setPointerCapture && g.setPointerCapture(e.pointerId);
+        svgElement.addEventListener('pointermove', onMove);
+        selectObject(id);
+      });
+      svgElement.addEventListener('pointerup', endDrag);
+      svgElement.addEventListener('pointerleave', endDrag);
+
+      timeline.addObject({ id, href, tx: 0, ty: 0, scale: 1, rotate: 0, attachedTo: null, layer });
+      selectObject(id);
+      onFrameChange();
+      onSave();
+    }
+
+    function deleteObject(id) {
+      timeline.deleteObject(id);
+      const el = objectElements.get(id);
+      if (el) el.remove();
+      objectElements.delete(id);
+      onFrameChange();
+      onSave();
+    }
+
+    function setLayer(id, layer) {
+      timeline.updateObjectAllFrames(id, { layer });
+      const el = objectElements.get(id);
+      if (el) {
+        if (layer === 'front') objectsFrontGroup.appendChild(el); else objectsBackGroup.appendChild(el);
+      }
+      onFrameChange();
+      onSave();
+    }
+
+    function attachObject(id, memberId) {
+      const old = timeline.getCurrentFrame().objects.find(o => o.id === id);
+      if (!old) return;
+      const currentAttached = old.attachedTo;
+      if (currentAttached) {
+        const pivotOld = pivots[currentAttached];
+        timeline.frames.forEach(f => {
+          const o = f.objects.find(ob => ob.id === id);
+          if (o) { o.tx += pivotOld.x; o.ty += pivotOld.y; }
+        });
+      }
+      if (memberId) {
+        const pivot = pivots[memberId];
+        timeline.frames.forEach(f => {
+          const o = f.objects.find(ob => ob.id === id);
+          if (o) { o.tx -= pivot.x; o.ty -= pivot.y; o.attachedTo = memberId; }
+        });
+      } else {
+        timeline.updateObjectAllFrames(id, { attachedTo: null });
+      }
+      onFrameChange();
+      onSave();
+    }
 
     // Function to apply a frame to a given SVG element (main pantin or ghost)
     const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = targetRootGroup._memberMap || memberElements) => {
@@ -74,10 +214,19 @@ async function main() {
 
       // Apply to main pantin
       applyFrameToPantinElement(frame, pantinRootGroup);
+      renderObjects(frame);
 
       // Update inspector values
-      scaleValueEl.textContent = frame.transform.scale.toFixed(2);
-      rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      if (appState.selected.type === 'pantin') {
+        scaleValueEl.textContent = frame.transform.scale.toFixed(2);
+        rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      } else {
+        const obj = frame.objects.find(o => o.id === appState.selected.id);
+        if (obj) {
+          scaleValueEl.textContent = obj.scale.toFixed(2);
+          rotateValueEl.textContent = Math.round(obj.rotate);
+        }
+      }
 
       // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
@@ -97,7 +246,7 @@ async function main() {
     const teardownGlobal = setupPantinGlobalInteractions(svgElement, interactionOptions, timeline, onFrameChange, onSave);
 
     debugLog("Initializing UI...");
-    initUI(timeline, onFrameChange, onSave);
+    initUI(timeline, onFrameChange, onSave, { addObject, deleteObject, setLayer, attachObject, selectPantin }, memberList);
 
     window.addEventListener('beforeunload', () => {
       teardownMembers();

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,3 @@
+export const appState = {
+  selected: { type: 'pantin', id: null }
+};

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -23,6 +23,7 @@ export class Timeline {
     return {
       transform: { tx: 0, ty: 0, scale: 1, rotate: 0 },
       members,
+      objects: [],
     };
   }
 
@@ -45,6 +46,33 @@ export class Timeline {
   updateTransform(values) {
     const frame = this.getCurrentFrame();
     frame.transform = { ...frame.transform, ...values };
+  }
+
+  addObject(obj) {
+    const base = { ...obj };
+    this.frames.forEach(f => {
+      f.objects.push(structuredClone ? structuredClone(base) : JSON.parse(JSON.stringify(base)));
+    });
+  }
+
+  updateObject(id, values) {
+    const frame = this.getCurrentFrame();
+    const obj = frame.objects.find(o => o.id === id);
+    if (obj) Object.assign(obj, values);
+  }
+
+  updateObjectAllFrames(id, values) {
+    this.frames.forEach(f => {
+      const obj = f.objects.find(o => o.id === id);
+      if (obj) Object.assign(obj, values);
+    });
+  }
+
+  deleteObject(id) {
+    this.frames.forEach(f => {
+      const idx = f.objects.findIndex(o => o.id === id);
+      if (idx >= 0) f.objects.splice(idx, 1);
+    });
   }
 
   addFrame(duplicate = true) {


### PR DESCRIPTION
## Summary
- allow importing images/SVG as scene objects with drag, scale and rotation controls
- persist object transformations on the timeline and attach them to puppet limbs
- add UI controls for adding, ordering, attaching or deleting objects

## Testing
- `node --check src/state.js src/timeline.js src/ui.js src/main.js`


------
https://chatgpt.com/codex/tasks/task_e_689004e67fb4832bbcebd52938b3f601