### PR TITLE
feat: allow adding persistent scene objects

### DIFF
--- a/assets/objets/objets.json
+++ b/assets/objets/objets.json
@@ -1,0 +1,5 @@
+[
+  {"id":"faucille","file":"faucille.svg"},
+  {"id":"marteau","file":"marteau.svg"},
+  {"id":"carre","file":"carre.svg"}
+]

--- a/index.html
+++ b/index.html
@@ -34,6 +34,29 @@
           </div>
         </div>
       </div>
+
+      <div id="object-inspector">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-library">Bibliothèque</label>
+          <select id="object-library"></select>
+          <button type="button" id="add-object" aria-label="Ajouter l'objet">➕</button>
+        </div>
+        <div class="control-group">
+          <label for="object-layer">Plan</label>
+          <select id="object-layer">
+            <option value="front">Devant</option>
+            <option value="back">Derrière</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label for="object-attach">Attacher à</label>
+          <select id="object-attach">
+            <option value="">Aucun</option>
+          </select>
+        </div>
+        <button type="button" id="delete-object" aria-label="Supprimer l'objet">Supprimer</button>
+      </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">

--- a/src/main.js
+++ b/src/main.js
@@ -15,10 +15,6 @@ async function main() {
     debugLog("SVG loaded, Timeline instantiated.");
     const timeline = new Timeline(memberList);
 
-    // Cache frequently accessed DOM elements
-    const scaleValueEl = document.getElementById('scale-value');
-    const rotateValueEl = document.getElementById('rotate-value');
-
     // Cache elements for transformations
     const pantinRootGroup = svgElement.querySelector(`#${PANTIN_ROOT_ID}`);
     const grabEl = pantinRootGroup?.querySelector(`#${GRAB_ID}`);
@@ -33,6 +29,170 @@ async function main() {
       if (el) memberElements[id] = el;
     });
     pantinRootGroup._memberMap = memberElements;
+
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const objectsBackGroup = document.createElementNS(SVG_NS, 'g');
+    objectsBackGroup.id = 'objects-back';
+    pantinRootGroup.parentNode.insertBefore(objectsBackGroup, pantinRootGroup);
+    const objectsFrontGroup = document.createElementNS(SVG_NS, 'g');
+    objectsFrontGroup.id = 'objects-front';
+    pantinRootGroup.parentNode.insertBefore(objectsFrontGroup, pantinRootGroup.nextSibling);
+    const objectElements = {};
+    let selectedObjectId = null;
+
+    const getSVGCoords = e => {
+      const pt = svgElement.createSVGPoint();
+      pt.x = e.clientX; pt.y = e.clientY;
+      return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+    };
+
+    function selectObject(id) {
+      selectedObjectId = id;
+      const frame = timeline.getCurrentFrame();
+      const values = id ? frame.objects[id] : frame.transform;
+      window.updateInspectorSelection(id ? `Objet ${id}` : 'Pantin', values);
+      document.getElementById('object-layer').value = id ? (timeline.objects[id]?.layer || 'front') : 'front';
+      document.getElementById('object-attach').value = id ? (timeline.objects[id]?.attachedTo || '') : '';
+    }
+
+    pantinRootGroup.addEventListener('pointerdown', () => selectObject(null));
+    svgElement.addEventListener('pointerdown', e => {
+      if (e.target === svgElement) selectObject(null);
+    });
+
+    window.appState = {
+      getSelectedObject: () => selectedObjectId,
+    };
+
+    function moveObjectToLayer(id) {
+      const meta = timeline.objects[id];
+      const el = objectElements[id];
+      if (!meta || !el) return;
+      const parent = meta.layer === 'back' ? objectsBackGroup : objectsFrontGroup;
+      parent.appendChild(el);
+    }
+
+    function createObjectElement(id) {
+      const meta = timeline.objects[id];
+      const g = document.createElementNS(SVG_NS, 'g');
+      g.dataset.obj = id;
+      const img = document.createElementNS(SVG_NS, 'image');
+      img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', `assets/objets/${meta.src}`);
+      img.setAttribute('width', 100);
+      img.setAttribute('height', 100);
+      g.appendChild(img);
+      g.style.cursor = 'move';
+      objectElements[id] = g;
+      moveObjectToLayer(id);
+
+      let dragging = false;
+      let start;
+      g.addEventListener('pointerdown', e => {
+        e.stopPropagation();
+        selectObject(id);
+        dragging = true;
+        start = getSVGCoords(e);
+        g.setPointerCapture && g.setPointerCapture(e.pointerId);
+        svgElement.addEventListener('pointermove', onMove);
+        svgElement.addEventListener('pointerup', endDrag, { once: true });
+      });
+
+      const onMove = e => {
+        if (!dragging) return;
+        const pt = getSVGCoords(e);
+        const frame = timeline.getCurrentFrame().objects[id];
+        timeline.updateObjectTransform(id, { tx: frame.tx + (pt.x - start.x), ty: frame.ty + (pt.y - start.y) });
+        start = pt;
+        onFrameChange();
+      };
+
+      const endDrag = () => {
+        dragging = false;
+        svgElement.removeEventListener('pointermove', onMove);
+        onSave();
+      };
+    }
+
+    function applyObjects(frame) {
+      Object.keys(timeline.objects).forEach(id => {
+        const meta = timeline.objects[id];
+        const objFrame = frame.objects[id];
+        const el = objectElements[id];
+        if (!meta || !objFrame || !el) return;
+        let m = svgElement.createSVGMatrix();
+        m = m.translate(objFrame.tx, objFrame.ty);
+        m = m.rotate(objFrame.rotate);
+        m = m.scale(objFrame.scale);
+        if (meta.attachedTo && memberElements[meta.attachedTo]) {
+          m = memberElements[meta.attachedTo].getCTM().multiply(m);
+        }
+        el.setAttribute('transform', `matrix(${m.a} ${m.b} ${m.c} ${m.d} ${m.e} ${m.f})`);
+      });
+    }
+
+    function setupObjectUI() {
+      const librarySelect = document.getElementById('object-library');
+      const layerSelect = document.getElementById('object-layer');
+      const attachSelect = document.getElementById('object-attach');
+      const addBtn = document.getElementById('add-object');
+      const delBtn = document.getElementById('delete-object');
+
+      fetch('assets/objets/objets.json')
+        .then(r => r.json())
+        .then(list => {
+          list.forEach(o => {
+            const opt = document.createElement('option');
+            opt.value = o.file;
+            opt.textContent = o.id;
+            librarySelect.appendChild(opt);
+          });
+        });
+
+      memberList.forEach(id => {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = id;
+        attachSelect.appendChild(opt);
+      });
+
+      addBtn.addEventListener('click', () => {
+        const file = librarySelect.value;
+        if (!file) return;
+        const id = 'obj' + Date.now();
+        timeline.addObject(id, { src: file, layer: layerSelect.value, attachedTo: attachSelect.value || null });
+        createObjectElement(id);
+        selectObject(id);
+        onSave();
+        onFrameChange();
+      });
+
+      layerSelect.addEventListener('change', () => {
+        if (!selectedObjectId) return;
+        timeline.updateObjectMeta(selectedObjectId, { layer: layerSelect.value });
+        moveObjectToLayer(selectedObjectId);
+        onSave();
+      });
+
+      attachSelect.addEventListener('change', () => {
+        if (!selectedObjectId) return;
+        const member = attachSelect.value || null;
+        timeline.updateObjectMeta(selectedObjectId, { attachedTo: member });
+        onSave();
+        onFrameChange();
+      });
+
+      delBtn.addEventListener('click', () => {
+        if (!selectedObjectId) return;
+        timeline.deleteObject(selectedObjectId);
+        const el = objectElements[selectedObjectId];
+        if (el) el.remove();
+        delete objectElements[selectedObjectId];
+        selectedObjectId = null;
+        selectObject(null);
+        onSave();
+        onFrameChange();
+      });
+    }
 
     // Function to apply a frame to a given SVG element (main pantin or ghost)
     const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = targetRootGroup._memberMap || memberElements) => {
@@ -62,6 +222,7 @@ async function main() {
       try {
         timeline.importJSON(savedData);
         debugLog("Animation chargée depuis localStorage.");
+        Object.keys(timeline.objects).forEach(id => createObjectElement(id));
       } catch (e) {
         console.warn("Impossible de charger l'animation sauvegardée:", e);
       }
@@ -72,14 +233,12 @@ async function main() {
       const frame = timeline.getCurrentFrame();
       if (!frame) return;
 
-      // Apply to main pantin
       applyFrameToPantinElement(frame, pantinRootGroup);
+      applyObjects(frame);
 
-      // Update inspector values
-      scaleValueEl.textContent = frame.transform.scale.toFixed(2);
-      rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      const target = selectedObjectId ? frame.objects[selectedObjectId] : frame.transform;
+      window.updateInspectorSelection(selectedObjectId ? `Objet ${selectedObjectId}` : 'Pantin', target);
 
-      // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
     };
 
@@ -98,6 +257,8 @@ async function main() {
 
     debugLog("Initializing UI...");
     initUI(timeline, onFrameChange, onSave);
+    setupObjectUI();
+    selectObject(null);
 
     window.addEventListener('beforeunload', () => {
       teardownMembers();

--- a/src/ui.js
+++ b/src/ui.js
@@ -25,6 +25,15 @@ export function initUI(timeline, onFrameChange, onSave) {
   const onionSkinToggle = document.getElementById('onion-skin-toggle');
   const pastFramesInput = document.getElementById('past-frames');
   const futureFramesInput = document.getElementById('future-frames');
+  const scaleValueEl = document.getElementById('scale-value');
+  const rotateValueEl = document.getElementById('rotate-value');
+  const selectedNameEl = document.getElementById('selected-element-name');
+
+  window.updateInspectorSelection = (name, values) => {
+    selectedNameEl.textContent = name;
+    scaleValueEl.textContent = values.scale.toFixed(2);
+    rotateValueEl.textContent = Math.round(values.rotate);
+  };
 
   // --- Panneau Inspecteur Escamotable ---
   const appContainer = document.getElementById('app-container');
@@ -190,15 +199,20 @@ export function initUI(timeline, onFrameChange, onSave) {
 
   function updateTransform(key, delta) {
     debugLog(`updateTransform for ${key} by ${delta}.`);
+    const sel = window.appState?.getSelectedObject();
     const currentFrame = timeline.getCurrentFrame();
-    const currentValue = currentFrame.transform[key];
-    let newValue = currentValue + delta;
+    const target = sel ? currentFrame.objects[sel] : currentFrame.transform;
+    let newValue = target[key] + delta;
     if (key === 'scale') {
       newValue = Math.min(Math.max(newValue, 0.1), 10);
     } else if (key === 'rotate') {
       newValue = ((newValue % 360) + 360) % 360;
     }
-    timeline.updateTransform({ [key]: newValue });
+    if (sel) {
+      timeline.updateObjectTransform(sel, { [key]: newValue });
+    } else {
+      timeline.updateTransform({ [key]: newValue });
+    }
     updateUI();
     onSave();
   }

--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ body, html {
   background-color: var(--panel-bg-color);
   border-left: 1px solid var(--border-color);
   padding: 16px;
-  overflow: hidden;
+  overflow-y: auto;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- support adding/removing scene objects that persist on the timeline
- enable selecting, attaching, layering and transforming objects via the inspector
- make inspector scrollable for better usability and ship object library manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901469532c832ba9608f49fd8bf4a8