### PR TITLE
Add basic persistent object support and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,30 @@
           </div>
         </div>
       </div>
+      <div id="object-controls">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-select">Ajouter</label>
+          <div class="value-stepper">
+            <select id="object-select"></select>
+            <button type="button" id="add-object" aria-label="Ajouter l'objet">+</button>
+          </div>
+        </div>
+        <div class="control-group">
+          <label for="layer-select">Plan</label>
+          <select id="layer-select">
+            <option value="front">Devant</option>
+            <option value="back" selected>Derrière</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label for="attach-select">Coller à</label>
+          <select id="attach-select"></select>
+        </div>
+        <div class="control-group">
+          <button type="button" id="delete-object" aria-label="Supprimer l'objet">Supprimer</button>
+        </div>
+      </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,9 @@ export const CONFIG = {
   SVG_URL: params.get('svg') || 'assets/pantins/manu.svg',
   THEATRE_ID: params.get('theatre') || 'theatre',
   PANTIN_ROOT_ID: params.get('root') || 'manu_test',
-  GRAB_ID: params.get('grab') || 'torse'
+  GRAB_ID: params.get('grab') || 'torse',
+  // Liste des fichiers d'objets disponibles dans assets/objets
+  OBJECT_ASSETS: ['carre.svg', 'faucille.svg', 'marteau.svg']
 };
 
 export default CONFIG;

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { initUI } from './ui.js';
 import { debugLog } from './debug.js';
 import CONFIG from './config.js';
 
-const { SVG_URL, THEATRE_ID, PANTIN_ROOT_ID, GRAB_ID } = CONFIG;
+const { SVG_URL, THEATRE_ID, PANTIN_ROOT_ID, GRAB_ID, OBJECT_ASSETS } = CONFIG;
 
 async function main() {
   debugLog("main() started");
@@ -18,6 +18,12 @@ async function main() {
     // Cache frequently accessed DOM elements
     const scaleValueEl = document.getElementById('scale-value');
     const rotateValueEl = document.getElementById('rotate-value');
+    const selectedElementNameEl = document.getElementById('selected-element-name');
+    const objectSelectEl = document.getElementById('object-select');
+    const addObjectBtn = document.getElementById('add-object');
+    const deleteObjectBtn = document.getElementById('delete-object');
+    const layerSelectEl = document.getElementById('layer-select');
+    const attachSelectEl = document.getElementById('attach-select');
 
     // Cache elements for transformations
     const pantinRootGroup = svgElement.querySelector(`#${PANTIN_ROOT_ID}`);
@@ -33,6 +39,167 @@ async function main() {
       if (el) memberElements[id] = el;
     });
     pantinRootGroup._memberMap = memberElements;
+
+    // Populate object asset list and attachment options
+    OBJECT_ASSETS.forEach(name => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      objectSelectEl.appendChild(opt);
+    });
+    attachSelectEl.appendChild(new Option('Aucun', ''));
+    memberList.forEach(id => attachSelectEl.appendChild(new Option(id, id)));
+
+    const objectsBehindGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    objectsBehindGroup.id = 'objects-behind';
+    pantinRootGroup.parentNode.insertBefore(objectsBehindGroup, pantinRootGroup);
+
+    const objectsFrontGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    objectsFrontGroup.id = 'objects-front';
+    pantinRootGroup.parentNode.insertBefore(objectsFrontGroup, pantinRootGroup.nextSibling);
+
+    const objectElements = {};
+    let objectIdCounter = 0;
+
+    const state = { selection: { type: 'pantin', id: null } };
+
+    const svgPoint = svgElement.createSVGPoint();
+    function getSVGCoords(evt) {
+      svgPoint.x = evt.clientX;
+      svgPoint.y = evt.clientY;
+      return svgPoint.matrixTransform(svgElement.getScreenCTM().inverse());
+    }
+
+    function applyObjects(frame) {
+      const objs = frame.objects || {};
+      Object.entries(objs).forEach(([id, obj]) => {
+        let el = objectElements[id];
+        if (!el) {
+          el = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+          el.setAttribute('href', `assets/objets/${obj.src}`);
+          el.setAttribute('width', 100);
+          el.setAttribute('height', 100);
+          el.style.cursor = 'move';
+          setupObjectDrag(el, id);
+          objectElements[id] = el;
+        }
+        const parent = obj.attachTo
+          ? memberElements[obj.attachTo]
+          : (obj.front ? objectsFrontGroup : objectsBehindGroup);
+        if (el.parentNode !== parent) parent.appendChild(el);
+        el.setAttribute('transform', `translate(${obj.tx},${obj.ty}) rotate(${obj.rotate},50,50) scale(${obj.scale})`);
+      });
+
+      Object.keys(objectElements).forEach(id => {
+        if (!(id in objs)) {
+          objectElements[id].remove();
+          delete objectElements[id];
+        }
+      });
+    }
+
+    function selectPantin() {
+      state.selection = { type: 'pantin', id: null };
+      selectedElementNameEl.textContent = 'Pantin';
+      layerSelectEl.disabled = true;
+      attachSelectEl.disabled = true;
+      deleteObjectBtn.disabled = true;
+      onFrameChange();
+    }
+
+    function selectObject(id) {
+      state.selection = { type: 'object', id };
+      selectedElementNameEl.textContent = id;
+      layerSelectEl.disabled = false;
+      attachSelectEl.disabled = false;
+      deleteObjectBtn.disabled = false;
+      onFrameChange();
+    }
+
+    function setupObjectDrag(el, id) {
+      let dragging = false;
+      let startPt;
+      el.addEventListener('pointerdown', e => {
+        dragging = true;
+        startPt = getSVGCoords(e);
+        selectObject(id);
+        el.setPointerCapture(e.pointerId);
+        e.stopPropagation();
+      });
+      svgElement.addEventListener('pointermove', e => {
+        if (!dragging) return;
+        const pt = getSVGCoords(e);
+        const dx = pt.x - startPt.x;
+        const dy = pt.y - startPt.y;
+        const frame = timeline.getCurrentFrame();
+        const obj = frame.objects[id];
+        obj.tx += dx;
+        obj.ty += dy;
+        startPt = pt;
+        applyObjects(frame);
+      });
+      svgElement.addEventListener('pointerup', e => {
+        if (!dragging) return;
+        dragging = false;
+        el.releasePointerCapture(e.pointerId);
+        onSave();
+      });
+    }
+
+    function addObject(asset) {
+      const id = `obj${++objectIdCounter}`;
+      timeline.addObject(id, { src: asset, tx: 0, ty: 0, scale: 1, rotate: 0, front: false, attachTo: null });
+      applyObjects(timeline.getCurrentFrame());
+      selectObject(id);
+      onSave();
+    }
+
+    function removeObject(id) {
+      timeline.deleteObject(id);
+      if (objectElements[id]) {
+        objectElements[id].remove();
+        delete objectElements[id];
+      }
+      selectPantin();
+      onSave();
+    }
+
+    function setObjectLayer(id, front) {
+      timeline.updateObject(id, { front });
+      applyObjects(timeline.getCurrentFrame());
+      onSave();
+    }
+
+    function attachObject(id, memberId) {
+      timeline.updateObject(id, { attachTo: memberId || null });
+      applyObjects(timeline.getCurrentFrame());
+      onSave();
+    }
+
+    const onUpdateTransform = (key, delta) => {
+      const frame = timeline.getCurrentFrame();
+      if (state.selection.type === 'pantin') {
+        const currentValue = frame.transform[key];
+        let newValue = currentValue + delta;
+        if (key === 'scale') {
+          newValue = Math.min(Math.max(newValue, 0.1), 10);
+        } else if (key === 'rotate') {
+          newValue = ((newValue % 360) + 360) % 360;
+        }
+        timeline.updateTransform({ [key]: newValue });
+      } else {
+        const obj = frame.objects[state.selection.id];
+        if (!obj) return;
+        const currentValue = obj[key];
+        let newValue = currentValue + delta;
+        if (key === 'scale') {
+          newValue = Math.min(Math.max(newValue, 0.1), 10);
+        } else if (key === 'rotate') {
+          newValue = ((newValue % 360) + 360) % 360;
+        }
+        timeline.updateObject(state.selection.id, { [key]: newValue });
+      }
+    };
 
     // Function to apply a frame to a given SVG element (main pantin or ghost)
     const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = targetRootGroup._memberMap || memberElements) => {
@@ -67,6 +234,14 @@ async function main() {
       }
     }
 
+    // Ajuste le compteur d'objets existants
+    const initialObjs = timeline.getCurrentFrame().objects || {};
+    const maxExisting = Object.keys(initialObjs).reduce((m, id) => {
+      const n = parseInt(id.replace('obj', ''));
+      return isNaN(n) ? m : Math.max(m, n);
+    }, 0);
+    objectIdCounter = maxExisting;
+
     const onFrameChange = () => {
       debugLog("onFrameChange triggered. Current frame:", timeline.current);
       const frame = timeline.getCurrentFrame();
@@ -75,16 +250,55 @@ async function main() {
       // Apply to main pantin
       applyFrameToPantinElement(frame, pantinRootGroup);
 
-      // Update inspector values
-      scaleValueEl.textContent = frame.transform.scale.toFixed(2);
-      rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      // Apply objects
+      applyObjects(frame);
+
+      // Update inspector values based on selection
+      if (state.selection.type === 'pantin') {
+        scaleValueEl.textContent = frame.transform.scale.toFixed(2);
+        rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      } else {
+        const obj = frame.objects[state.selection.id];
+        if (obj) {
+          scaleValueEl.textContent = obj.scale.toFixed(2);
+          rotateValueEl.textContent = Math.round(obj.rotate);
+          layerSelectEl.value = obj.front ? 'front' : 'back';
+          attachSelectEl.value = obj.attachTo || '';
+        }
+      }
 
       // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
     };
 
+    // Bind UI controls for objects
+    addObjectBtn.addEventListener('click', () => {
+      const asset = objectSelectEl.value;
+      if (asset) addObject(asset);
+    });
+
+    deleteObjectBtn.addEventListener('click', () => {
+      if (state.selection.type === 'object') {
+        removeObject(state.selection.id);
+      }
+    });
+
+    layerSelectEl.addEventListener('change', () => {
+      if (state.selection.type === 'object') {
+        setObjectLayer(state.selection.id, layerSelectEl.value === 'front');
+      }
+    });
+
+    attachSelectEl.addEventListener('change', () => {
+      if (state.selection.type === 'object') {
+        attachObject(state.selection.id, attachSelectEl.value || null);
+      }
+    });
+
     debugLog("Initializing Onion Skin...");
     initOnionSkin(svgElement, PANTIN_ROOT_ID, memberList);
+
+    selectPantin();
 
     const interactionOptions = {
       rootGroupId: PANTIN_ROOT_ID,
@@ -97,7 +311,7 @@ async function main() {
     const teardownGlobal = setupPantinGlobalInteractions(svgElement, interactionOptions, timeline, onFrameChange, onSave);
 
     debugLog("Initializing UI...");
-    initUI(timeline, onFrameChange, onSave);
+    initUI(timeline, onFrameChange, onSave, onUpdateTransform);
 
     window.addEventListener('beforeunload', () => {
       teardownMembers();

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -23,6 +23,7 @@ export class Timeline {
     return {
       transform: { tx: 0, ty: 0, scale: 1, rotate: 0 },
       members,
+      objects: {}
     };
   }
 
@@ -45,6 +46,27 @@ export class Timeline {
   updateTransform(values) {
     const frame = this.getCurrentFrame();
     frame.transform = { ...frame.transform, ...values };
+  }
+
+  // --- Gestion des objets ---
+  addObject(id, data) {
+    this.frames.forEach(f => {
+      if (!f.objects) f.objects = {};
+      f.objects[id] = { ...data };
+    });
+  }
+
+  updateObject(id, values) {
+    const frame = this.getCurrentFrame();
+    if (!frame.objects) frame.objects = {};
+    if (!frame.objects[id]) return;
+    frame.objects[id] = { ...frame.objects[id], ...values };
+  }
+
+  deleteObject(id) {
+    this.frames.forEach(f => {
+      if (f.objects && f.objects[id]) delete f.objects[id];
+    });
   }
 
   addFrame(duplicate = true) {
@@ -147,6 +169,7 @@ export class Timeline {
       }
     });
     // Les transformations globales seront celles par défaut
+    newFrame.objects = oldFrame.objects || {};
     return newFrame;
   }
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -7,7 +7,7 @@ import { debugLog } from './debug.js';
  * @param {Function} onFrameChange - Callback pour rafraîchir le SVG.
  * @param {Function} onSave - Callback pour sauvegarder l'état.
  */
-export function initUI(timeline, onFrameChange, onSave) {
+export function initUI(timeline, onFrameChange, onSave, onUpdateTransform) {
   debugLog("initUI called.");
   const frameInfo = document.getElementById('frameInfo');
   const timelineSlider = document.getElementById('timeline-slider');
@@ -190,15 +190,9 @@ export function initUI(timeline, onFrameChange, onSave) {
 
   function updateTransform(key, delta) {
     debugLog(`updateTransform for ${key} by ${delta}.`);
-    const currentFrame = timeline.getCurrentFrame();
-    const currentValue = currentFrame.transform[key];
-    let newValue = currentValue + delta;
-    if (key === 'scale') {
-      newValue = Math.min(Math.max(newValue, 0.1), 10);
-    } else if (key === 'rotate') {
-      newValue = ((newValue % 360) + 360) % 360;
+    if (typeof onUpdateTransform === 'function') {
+      onUpdateTransform(key, delta);
     }
-    timeline.updateTransform({ [key]: newValue });
     updateUI();
     onSave();
   }

--- a/style.css
+++ b/style.css
@@ -110,6 +110,11 @@ body, html {
   padding: 0 10px;
 }
 
+#object-controls .value-stepper select {
+  flex: 1;
+  margin-right: 8px;
+}
+
 #timeline-panel {
   grid-area: timeline;
   display: flex;


### PR DESCRIPTION
## Summary
- allow adding SVG/PNG objects from `assets/objets` and manage them in the scene
- persist object transforms on the animation timeline
- revise inspector UI with object controls and cleaner layout

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/main.js`
- `node --check src/config.js src/timeline.js src/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68901469532c832ba9608f49fd8bf4a8