### PR TITLE
feat: add scene objects with timeline persistence

### DIFF
--- a/assets/objets/manifest.json
+++ b/assets/objets/manifest.json
@@ -1,0 +1,5 @@
+{
+  "carre": "assets/objets/carre.svg",
+  "faucille": "assets/objets/faucille.svg",
+  "marteau": "assets/objets/marteau.svg"
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
         <label for="selected-element-name">Sélection</label>
         <output id="selected-element-name">Pantin</output>
       </div>
+      <div id="object-add" class="control-group">
+        <label for="object-select">Ajouter objet</label>
+        <select id="object-select"></select>
+        <button type="button" id="object-add-btn" aria-label="Ajouter un objet">+</button>
+      </div>
       <div id="pantin-controls">
         <div class="control-group">
           <label for="scale-value">Échelle</label>
@@ -32,6 +37,19 @@
             <output id="rotate-value" for="rotate-minus rotate-plus">0</output>
             <button type="button" id="rotate-plus" aria-label="Augmenter la rotation">+</button>
           </div>
+        </div>
+      </div>
+      <div id="object-controls" style="display:none;">
+        <div class="control-group">
+          <label for="object-parent">Attacher à</label>
+          <select id="object-parent">
+            <option value="">Scène</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <button type="button" id="send-back" aria-label="Derrière">⬇️</button>
+          <button type="button" id="bring-front" aria-label="Devant">⬆️</button>
+          <button type="button" id="delete-object" aria-label="Supprimer">🗑️</button>
         </div>
       </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { initOnionSkin, renderOnionSkins } from './onionSkin.js';
 import { loadSVG } from './svgLoader.js';
 import { Timeline } from './timeline.js';
-import { setupInteractions, setupPantinGlobalInteractions } from './interactions.js';
+import { setupInteractions, setupPantinGlobalInteractions, setupObjectInteractions } from './interactions.js';
 import { initUI } from './ui.js';
 import { debugLog } from './debug.js';
 import CONFIG from './config.js';
@@ -18,6 +18,15 @@ async function main() {
     // Cache frequently accessed DOM elements
     const scaleValueEl = document.getElementById('scale-value');
     const rotateValueEl = document.getElementById('rotate-value');
+    const selectedNameEl = document.getElementById('selected-element-name');
+    const pantinControls = document.getElementById('pantin-controls');
+    const objectControls = document.getElementById('object-controls');
+    const objectParentSelect = document.getElementById('object-parent');
+    const sendBackBtn = document.getElementById('send-back');
+    const bringFrontBtn = document.getElementById('bring-front');
+    const deleteObjectBtn = document.getElementById('delete-object');
+    const objectSelect = document.getElementById('object-select');
+    const objectAddBtn = document.getElementById('object-add-btn');
 
     // Cache elements for transformations
     const pantinRootGroup = svgElement.querySelector(`#${PANTIN_ROOT_ID}`);
@@ -33,6 +42,95 @@ async function main() {
       if (el) memberElements[id] = el;
     });
     pantinRootGroup._memberMap = memberElements;
+
+    // Layers and storage for scene objects
+    const objectsBackGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    objectsBackGroup.id = 'objects-back';
+    pantinRootGroup.parentNode.insertBefore(objectsBackGroup, pantinRootGroup);
+    const objectsFrontGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    objectsFrontGroup.id = 'objects-front';
+    pantinRootGroup.parentNode.insertBefore(objectsFrontGroup, pantinRootGroup.nextSibling);
+
+    const objectElements = {};
+    let selection = { type: 'pantin', id: null };
+
+    const refreshParentOptions = () => {
+      objectParentSelect.innerHTML = '<option value="">Scène</option>';
+      memberList.forEach(id => {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = id;
+        objectParentSelect.appendChild(opt);
+      });
+    };
+    refreshParentOptions();
+
+    const updateSelectionUI = () => {
+      if (selection.type === 'pantin') {
+        selectedNameEl.textContent = 'Pantin';
+        pantinControls.style.display = 'block';
+        objectControls.style.display = 'none';
+      } else {
+        const obj = timeline.objects.find(o => o.id === selection.id);
+        selectedNameEl.textContent = obj?.name || 'Objet';
+        pantinControls.style.display = 'block';
+        objectControls.style.display = 'block';
+        objectParentSelect.value = obj?.parent || '';
+      }
+    };
+
+    const updateSelectionValues = frame => {
+      if (selection.type === 'pantin') {
+        scaleValueEl.textContent = frame.transform.scale.toFixed(2);
+        rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      } else {
+        const st = frame.objects[selection.id];
+        if (st) {
+          scaleValueEl.textContent = st.scale.toFixed(2);
+          rotateValueEl.textContent = Math.round(st.rotate);
+        }
+      }
+    };
+
+    const selectObject = id => {
+      selection = { type: 'object', id };
+      Object.entries(objectElements).forEach(([oid, el]) => {
+        el.classList.toggle('selected-object', oid === id);
+      });
+      updateSelectionUI();
+      updateSelectionValues(timeline.getCurrentFrame());
+    };
+
+    const selectPantin = () => {
+      selection = { type: 'pantin', id: null };
+      Object.values(objectElements).forEach(el => el.classList.remove('selected-object'));
+      updateSelectionUI();
+      updateSelectionValues(timeline.getCurrentFrame());
+    };
+    selectPantin();
+
+    svgElement.addEventListener('click', e => {
+      if (e.target.classList.contains('scene-object')) return;
+      selectPantin();
+    });
+
+    const renderObject = obj => {
+      const el = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+      el.setAttribute('href', obj.src);
+      el.setAttribute('width', 100);
+      el.setAttribute('height', 100);
+      el.id = obj.id;
+      el.classList.add('scene-object');
+      const parentEl = obj.parent
+        ? pantinRootGroup.querySelector(`#${obj.parent}`)
+        : (obj.front ? objectsFrontGroup : objectsBackGroup);
+      if (obj.front) parentEl.appendChild(el); else parentEl.insertBefore(el, parentEl.firstChild);
+      const box = el.getBBox();
+      obj.cx = box.x + box.width / 2;
+      obj.cy = box.y + box.height / 2;
+      objectElements[obj.id] = el;
+      setupObjectInteractions(el, obj.id, timeline, onFrameChange, onSave, selectObject);
+    };
 
     // Function to apply a frame to a given SVG element (main pantin or ghost)
     const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = targetRootGroup._memberMap || memberElements) => {
@@ -67,6 +165,9 @@ async function main() {
       }
     }
 
+    // Render objects if any were saved
+    timeline.objects.forEach(renderObject);
+
     const onFrameChange = () => {
       debugLog("onFrameChange triggered. Current frame:", timeline.current);
       const frame = timeline.getCurrentFrame();
@@ -75,9 +176,19 @@ async function main() {
       // Apply to main pantin
       applyFrameToPantinElement(frame, pantinRootGroup);
 
-      // Update inspector values
-      scaleValueEl.textContent = frame.transform.scale.toFixed(2);
-      rotateValueEl.textContent = Math.round(frame.transform.rotate);
+      // Apply to objects
+      timeline.objects.forEach(obj => {
+        const el = objectElements[obj.id];
+        if (!el) return;
+        const st = frame.objects[obj.id];
+        if (!st) return;
+        el.setAttribute(
+          'transform',
+          `translate(${st.tx},${st.ty}) rotate(${st.rotate},${obj.cx},${obj.cy}) scale(${st.scale})`
+        );
+      });
+
+      updateSelectionValues(frame);
 
       // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
@@ -97,7 +208,81 @@ async function main() {
     const teardownGlobal = setupPantinGlobalInteractions(svgElement, interactionOptions, timeline, onFrameChange, onSave);
 
     debugLog("Initializing UI...");
-    initUI(timeline, onFrameChange, onSave);
+    initUI(timeline, onFrameChange, onSave, { getSelection: () => selection });
+
+    // Load available objects
+    fetch('assets/objets/manifest.json')
+      .then(r => r.json())
+      .then(data => {
+        Object.entries(data).forEach(([name, path]) => {
+          const opt = document.createElement('option');
+          opt.value = path;
+          opt.textContent = name;
+          objectSelect.appendChild(opt);
+        });
+      })
+      .catch(err => console.error('Manifest objets manquant', err));
+
+    objectAddBtn.addEventListener('click', () => {
+      const src = objectSelect.value;
+      if (!src) return;
+      const id = `obj-${Date.now()}`;
+      const name = src.split('/').pop();
+      const obj = { id, name, src, parent: null, front: true };
+      timeline.addObject(obj);
+      renderObject(obj);
+      selectObject(id);
+      onSave();
+    });
+
+    deleteObjectBtn.addEventListener('click', () => {
+      if (selection.type !== 'object') return;
+      const id = selection.id;
+      const el = objectElements[id];
+      el && el.parentNode && el.parentNode.removeChild(el);
+      delete objectElements[id];
+      timeline.removeObject(id);
+      selectPantin();
+      onSave();
+    });
+
+    objectParentSelect.addEventListener('change', () => {
+      if (selection.type !== 'object') return;
+      const obj = timeline.objects.find(o => o.id === selection.id);
+      obj.parent = objectParentSelect.value || null;
+      const el = objectElements[obj.id];
+      if (el) {
+        const parentEl = obj.parent
+          ? pantinRootGroup.querySelector(`#${obj.parent}`)
+          : (obj.front ? objectsFrontGroup : objectsBackGroup);
+        if (obj.front) parentEl.appendChild(el); else parentEl.insertBefore(el, parentEl.firstChild);
+      }
+      onSave();
+    });
+
+    bringFrontBtn.addEventListener('click', () => {
+      if (selection.type !== 'object') return;
+      const obj = timeline.objects.find(o => o.id === selection.id);
+      obj.front = true;
+      const el = objectElements[obj.id];
+      const parentEl = obj.parent
+        ? pantinRootGroup.querySelector(`#${obj.parent}`)
+        : objectsFrontGroup;
+      parentEl.appendChild(el);
+      onSave();
+    });
+
+    sendBackBtn.addEventListener('click', () => {
+      if (selection.type !== 'object') return;
+      const obj = timeline.objects.find(o => o.id === selection.id);
+      obj.front = false;
+      const el = objectElements[obj.id];
+      const parentEl = obj.parent
+        ? pantinRootGroup.querySelector(`#${obj.parent}`)
+        : objectsBackGroup;
+      parentEl.insertBefore(el, parentEl.firstChild);
+      onSave();
+    });
 
     window.addEventListener('beforeunload', () => {
       teardownMembers();

--- a/style.css
+++ b/style.css
@@ -194,3 +194,11 @@ button:hover, .button:hover {
   /* Example color for future frames */
   filter: hue-rotate(90deg) saturate(1.5); /* Greenish tint */
 }
+
+.scene-object {
+  cursor: move;
+}
+
+.scene-object.selected-object {
+  outline: 2px dashed var(--accent-color);
+}


### PR DESCRIPTION
## Summary
- enable adding external PNG/SVG objects from assets and manage them in inspector
- persist object transforms on timeline with front/back layering and pantin attachment
- allow dragging and removal of objects with updated UI controls

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check src/main.js && node --check src/interactions.js && node --check src/timeline.js && node --check src/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68901469532c832ba9608f49fd8bf4a8