### PR TITLE
feat: allow persistent scene objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,36 @@
           </div>
         </div>
       </div>
+      <div id="object-controls" role="region" aria-label="Objets">
+        <h3>Objets</h3>
+        <div class="control-group">
+          <label for="object-asset">Ajouter</label>
+          <select id="object-asset">
+            <option value="carre.svg">carre</option>
+            <option value="faucille.svg">faucille</option>
+            <option value="marteau.svg">marteau</option>
+          </select>
+          <button type="button" id="add-object">Ajouter</button>
+        </div>
+        <div class="control-group">
+          <label for="object-list">Sélection</label>
+          <select id="object-list" size="4"></select>
+          <button type="button" id="remove-object">Supprimer</button>
+        </div>
+        <div class="control-group">
+          <label for="object-layer">Calque</label>
+          <select id="object-layer">
+            <option value="front">Devant</option>
+            <option value="back">Derrière</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <label for="object-attach">Coller à</label>
+          <select id="object-attach">
+            <option value="">Aucun</option>
+          </select>
+        </div>
+      </div>
       <div id="onion-skin-controls" role="region" aria-label="Contrôles Onion Skin">
         <h3>Onion Skin</h3>
         <div class="control-group">

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { loadSVG } from './svgLoader.js';
 import { Timeline } from './timeline.js';
 import { setupInteractions, setupPantinGlobalInteractions } from './interactions.js';
 import { initUI } from './ui.js';
+import { initObjects } from './objects.js';
 import { debugLog } from './debug.js';
 import CONFIG from './config.js';
 
@@ -67,6 +68,8 @@ async function main() {
       }
     }
 
+    let objects;
+
     const onFrameChange = () => {
       debugLog("onFrameChange triggered. Current frame:", timeline.current);
       const frame = timeline.getCurrentFrame();
@@ -81,6 +84,9 @@ async function main() {
 
       // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
+
+      // Render scene objects
+      objects && objects.renderObjects();
     };
 
     debugLog("Initializing Onion Skin...");
@@ -91,13 +97,15 @@ async function main() {
       grabId: GRAB_ID,
     };
 
+    objects = initObjects(svgElement, PANTIN_ROOT_ID, timeline, memberList, onFrameChange, onSave);
+
     debugLog("Setting up member interactions...");
     const teardownMembers = setupInteractions(svgElement, memberList, pivots, timeline, onFrameChange, onSave);
     debugLog("Setting up global pantin interactions...");
     const teardownGlobal = setupPantinGlobalInteractions(svgElement, interactionOptions, timeline, onFrameChange, onSave);
 
     debugLog("Initializing UI...");
-    initUI(timeline, onFrameChange, onSave);
+    initUI(timeline, onFrameChange, onSave, objects);
 
     window.addEventListener('beforeunload', () => {
       teardownMembers();

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,0 +1,192 @@
+import { debugLog } from './debug.js';
+
+export function initObjects(svgElement, pantinRootId, timeline, memberList, onUpdate, onSave) {
+  debugLog('initObjects called');
+  const ns = 'http://www.w3.org/2000/svg';
+  const pantinRoot = svgElement.getElementById(pantinRootId);
+  const frontLayer = document.createElementNS(ns, 'g');
+  frontLayer.id = 'objects-front';
+  const backLayer = document.createElementNS(ns, 'g');
+  backLayer.id = 'objects-back';
+  pantinRoot.parentNode.insertBefore(backLayer, pantinRoot);
+  pantinRoot.parentNode.insertBefore(frontLayer, pantinRoot.nextSibling);
+
+  let selectedId = null;
+  let selectCallback = null;
+
+  function selectObject(id) {
+    selectedId = id;
+    document.querySelectorAll('.scene-object').forEach(el => el.classList.remove('selected'));
+    const el = svgElement.getElementById(id);
+    if (el) el.classList.add('selected');
+    if (selectCallback) selectCallback(id);
+  }
+
+  function addObject(src, layer = 'front') {
+    const id = `obj-${Date.now()}`;
+    timeline.addObject(id, { x: 0, y: 0, scale: 1, rotate: 0, layer, attachedTo: null, src: `assets/objets/${src}` });
+    const img = document.createElementNS(ns, 'image');
+    img.setAttribute('href', `assets/objets/${src}`);
+    img.setAttribute('width', 100);
+    img.setAttribute('height', 100);
+    img.id = id;
+    img.classList.add('scene-object');
+    (layer === 'front' ? frontLayer : backLayer).appendChild(img);
+    setupInteract(img, id);
+    selectObject(id);
+    onUpdate();
+    onSave();
+    return id;
+  }
+
+  function removeObject(id) {
+    timeline.removeObject(id);
+    const el = svgElement.getElementById(id);
+    if (el) el.remove();
+    if (selectedId === id) selectedId = null;
+    onUpdate();
+    onSave();
+  }
+
+  function setLayer(id, layer) {
+    timeline.updateObject(id, { layer });
+    const el = svgElement.getElementById(id);
+    if (!el) return;
+    (layer === 'front' ? frontLayer : backLayer).appendChild(el);
+    onUpdate();
+    onSave();
+  }
+
+  function attach(id, memberId) {
+    const frame = timeline.getCurrentFrame();
+    const obj = frame.objects[id];
+    if (!obj) return;
+    if (memberId) {
+      const seg = pantinRoot.querySelector(`#${memberId}`);
+      if (seg) {
+        const inv = seg.getCTM().inverse();
+        const pt = svgElement.createSVGPoint();
+        pt.x = obj.x;
+        pt.y = obj.y;
+        const local = pt.matrixTransform(inv);
+        obj.x = local.x;
+        obj.y = local.y;
+      }
+    } else if (obj.attachedTo) {
+      const seg = pantinRoot.querySelector(`#${obj.attachedTo}`);
+      if (seg) {
+        const matrix = seg.getCTM();
+        const pt = svgElement.createSVGPoint();
+        pt.x = obj.x;
+        pt.y = obj.y;
+        const g = pt.matrixTransform(matrix);
+        obj.x = g.x;
+        obj.y = g.y;
+      }
+    }
+    timeline.updateObject(id, { attachedTo: memberId || null, x: obj.x, y: obj.y });
+    onUpdate();
+    onSave();
+  }
+
+  function setupInteract(el, id) {
+    if (!window.interact) return;
+    window.interact(el).draggable({
+      listeners: {
+        move(event) {
+          const frame = timeline.getCurrentFrame();
+          const obj = frame.objects[id];
+          if (obj.attachedTo) {
+            const seg = pantinRoot.querySelector(`#${obj.attachedTo}`);
+            if (!seg) return;
+            const inv = seg.getCTM().inverse();
+            const pt = svgElement.createSVGPoint();
+            pt.x = event.dx;
+            pt.y = event.dy;
+            const local = pt.matrixTransform(inv);
+            timeline.updateObject(id, { x: obj.x + local.x, y: obj.y + local.y });
+          } else {
+            timeline.updateObject(id, { x: obj.x + event.dx, y: obj.y + event.dy });
+          }
+          onUpdate();
+        },
+        end: onSave,
+      },
+    }).gesturable({
+      listeners: {
+        move(event) {
+          const frame = timeline.getCurrentFrame();
+          const obj = frame.objects[id];
+          const scale = obj.scale * (1 + event.ds);
+          const rotate = obj.rotate + event.da;
+          timeline.updateObject(id, { scale, rotate });
+          onUpdate();
+        },
+        end: onSave,
+      },
+    });
+    el.addEventListener('click', () => selectObject(id));
+  }
+
+  function renderObjects() {
+    const frame = timeline.getCurrentFrame();
+    const existing = new Set();
+    Object.entries(frame.objects).forEach(([id, obj]) => {
+      existing.add(id);
+      let el = svgElement.getElementById(id);
+      if (!el) {
+        el = document.createElementNS(ns, 'image');
+        el.setAttribute('href', obj.src);
+        el.setAttribute('width', 100);
+        el.setAttribute('height', 100);
+        el.id = id;
+        el.classList.add('scene-object');
+        (obj.layer === 'front' ? frontLayer : backLayer).appendChild(el);
+        setupInteract(el, id);
+      }
+      const baseRotate = frame.transform.rotate;
+      const baseScale = frame.transform.scale;
+      if (obj.attachedTo) {
+        const seg = pantinRoot.querySelector(`#${obj.attachedTo}`);
+        if (seg) {
+          const matrix = seg.getCTM();
+          const pt = svgElement.createSVGPoint();
+          pt.x = obj.x;
+          pt.y = obj.y;
+          const g = pt.matrixTransform(matrix);
+          const segAngle = frame.members[obj.attachedTo]?.rotate || 0;
+          const totalRotate = obj.rotate + baseRotate + segAngle;
+          const totalScale = obj.scale * baseScale;
+          el.setAttribute('transform', `translate(${g.x},${g.y}) rotate(${totalRotate}) scale(${totalScale})`);
+        }
+      } else {
+        const totalRotate = obj.rotate + baseRotate;
+        const totalScale = obj.scale * baseScale;
+        const tx = obj.x + frame.transform.tx;
+        const ty = obj.y + frame.transform.ty;
+        el.setAttribute('transform', `translate(${tx},${ty}) rotate(${totalRotate}) scale(${totalScale})`);
+      }
+      if (selectedId === id) el.classList.add('selected');
+      else el.classList.remove('selected');
+    });
+    document.querySelectorAll('.scene-object').forEach(el => {
+      if (!existing.has(el.id)) el.remove();
+    });
+  }
+
+  function onSelect(cb) {
+    selectCallback = cb;
+  }
+
+  return {
+    addObject,
+    removeObject,
+    setLayer,
+    attach,
+    renderObjects,
+    getSelectedId: () => selectedId,
+    selectObject,
+    onSelect,
+    memberList,
+  };
+}

--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ body, html {
   background-color: var(--panel-bg-color);
   border-left: 1px solid var(--border-color);
   padding: 16px;
-  overflow: hidden;
+  overflow-y: auto;
   white-space: nowrap;
 }
 
@@ -78,6 +78,15 @@ body, html {
 
 #selected-element-name {
   color: var(--accent-color);
+}
+
+#object-controls select,
+#object-controls button {
+  width: 100%;
+}
+
+.scene-object.selected {
+  outline: 2px dashed var(--accent-color);
 }
 
 .control-group {


### PR DESCRIPTION
## Summary
- allow adding PNG/SVG objects to the scene and store their transforms on the timeline
- manage objects from the inspector (layering, attachment to pantin members, removal)
- render scene objects and keep them persistent across frames and refreshes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901469532c832ba9608f49fd8bf4a8