### PR TITLE
Refactor animation editor for performance and multi-puppet support

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -2,29 +2,29 @@
 
 import { debugLog } from './debug.js';
 
-// --- Global State Management ---
-const pantinState = {
-  rootGroup: null,
-  svgElement: null,
-};
-
 /** Setup global interactions: drag on torse, scale & rotate sliders. */
 export function setupPantinGlobalInteractions(svgElement, options, timeline, onUpdate, onEnd) {
   debugLog("setupPantinGlobalInteractions called.");
   const { rootGroupId, grabId } = options;
-  pantinState.svgElement = svgElement;
-  pantinState.rootGroup = svgElement.querySelector(`#${rootGroupId}`);
+  const rootGroup = svgElement.querySelector(`#${rootGroupId}`);
   const grabEl = svgElement.querySelector(`#${grabId}`);
   debugLog('Grab element:', grabEl); // Ligne de débogage
 
-  if (!pantinState.rootGroup || !grabEl) {
-    console.warn("Missing elements for global pantin interactions.", {pantinRoot: pantinState.rootGroup, grabEl});
+  if (!rootGroup || !grabEl) {
+    console.warn("Missing elements for global pantin interactions.", {pantinRoot: rootGroup, grabEl});
     return () => {};
   }
 
   let dragging = false;
   let startPt;
   grabEl.style.cursor = 'move';
+
+  const getSVGCoords = evt => {
+    const pt = svgElement.createSVGPoint();
+    pt.x = evt.clientX;
+    pt.y = evt.clientY;
+    return pt.matrixTransform(svgElement.getScreenCTM().inverse());
+  };
 
   const onMove = e => {
     if (!dragging) return;
@@ -69,14 +69,6 @@ export function setupPantinGlobalInteractions(svgElement, options, timeline, onU
     svgElement.removeEventListener('pointerup', endDrag);
     svgElement.removeEventListener('pointerleave', endDrag);
   };
-}
-
-// --- Utilities ---
-function getSVGCoords(evt) {
-  const pt = pantinState.svgElement.createSVGPoint();
-  pt.x = evt.clientX;
-  pt.y = evt.clientY;
-  return pt.matrixTransform(pantinState.svgElement.getScreenCTM().inverse());
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import { initUI } from './ui.js';
 import { initObjects } from './objects.js';
 import { debugLog } from './debug.js';
 import CONFIG from './config.js';
+import { memberMapStore } from './memberMapStore.js';
 
 const { SVG_URL, THEATRE_ID, PANTIN_ROOT_ID, GRAB_ID } = CONFIG;
 
@@ -33,10 +34,10 @@ async function main() {
       const el = pantinRootGroup?.querySelector(`#${id}`);
       if (el) memberElements[id] = el;
     });
-    pantinRootGroup._memberMap = memberElements;
+    memberMapStore.set(pantinRootGroup, memberElements);
 
     // Function to apply a frame to a given SVG element (main pantin or ghost)
-    const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = targetRootGroup._memberMap || memberElements) => {
+    const applyFrameToPantinElement = (targetFrame, targetRootGroup, elementMap = memberMapStore.get(targetRootGroup) || memberElements) => {
       debugLog("Applying frame to element:", targetRootGroup, "Frame data:", targetFrame);
       const { tx, ty, scale, rotate } = targetFrame.transform;
       targetRootGroup.setAttribute(

--- a/src/memberMapStore.js
+++ b/src/memberMapStore.js
@@ -1,0 +1,1 @@
+export const memberMapStore = new WeakMap();

--- a/src/svgLoader.js
+++ b/src/svgLoader.js
@@ -1,4 +1,5 @@
 // src/svgLoader.js
+import { debugLog } from './debug.js';
 
 /**
  * Charge le fichier SVG, l'injecte dans le DOM et prépare les éléments.
@@ -37,13 +38,25 @@ export async function loadSVG(url, targetId) {
   ].forEach(([childId, parentId]) => {
     const ch = svgElement.getElementById(childId);
     const pr = svgElement.getElementById(parentId);
-    if (ch && pr && ch.parentNode !== pr) pr.appendChild(ch);
+    if (ch && pr) {
+      if (ch.parentNode !== pr) {
+        pr.appendChild(ch);
+        debugLog(`Reparented ${childId} under ${parentId}`);
+      }
+    } else {
+      console.warn(`Missing element for reparenting: child=${childId}, parent=${parentId}`);
+    }
   });
 
   const torso = svgElement.getElementById('torse');
   ['tete', 'bras_gauche', 'bras_droite', 'jambe_gauche', 'jambe_droite'].forEach(id => {
     const el = svgElement.getElementById(id);
-    if (el && torso && torso.parentNode) torso.parentNode.insertBefore(el, torso);
+    if (el && torso && torso.parentNode) {
+      torso.parentNode.insertBefore(el, torso);
+      debugLog(`Moved ${id} before torse`);
+    } else {
+      console.warn(`Unable to reinsert ${id} before torse`);
+    }
   });
 
   const joints = [

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -16,6 +16,7 @@ export class Timeline {
     this.current = 0;
     this.playing = false;
     this._rafId = null;
+    this.objectStore = {};
   }
 
   createEmptyFrame() {
@@ -46,27 +47,57 @@ export class Timeline {
 
   updateTransform(values) {
     const frame = this.getCurrentFrame();
-    frame.transform = { ...frame.transform, ...values };
+    const updated = { ...frame.transform, ...values };
+    if ('scale' in values) {
+      updated.scale = Math.min(Math.max(updated.scale, 0.1), 10);
+    }
+    if ('rotate' in values) {
+      updated.rotate = ((updated.rotate % 360) + 360) % 360;
+    }
+    frame.transform = updated;
   }
 
   addObject(id, data) {
+    const { src, width, height, ...transform } = data;
+    this.objectStore[id] = { src, width, height };
     this.frames.forEach(f => {
-      f.objects[id] = typeof structuredClone === 'function'
-        ? structuredClone(data)
-        : JSON.parse(JSON.stringify(data));
+      f.objects[id] = { ...transform };
     });
   }
 
   updateObject(id, values) {
     const frame = this.getCurrentFrame();
     if (!frame.objects[id]) return;
-    frame.objects[id] = { ...frame.objects[id], ...values };
+    const constant = {};
+    const transform = { ...frame.objects[id] };
+    ['src', 'width', 'height'].forEach(k => {
+      if (k in values) constant[k] = values[k];
+    });
+    Object.assign(transform, values);
+    if ('scale' in values) {
+      transform.scale = Math.min(Math.max(transform.scale, 0.1), 10);
+    }
+    if ('rotate' in values) {
+      transform.rotate = ((transform.rotate % 360) + 360) % 360;
+    }
+    frame.objects[id] = transform;
+    if (Object.keys(constant).length) {
+      this.objectStore[id] = { ...this.objectStore[id], ...constant };
+    }
   }
 
   removeObject(id) {
+    delete this.objectStore[id];
     this.frames.forEach(f => {
       delete f.objects[id];
     });
+  }
+
+  getObject(id) {
+    const frame = this.getCurrentFrame();
+    const transform = frame.objects[id];
+    if (!transform) return null;
+    return { ...this.objectStore[id], ...transform };
   }
 
   addFrame(duplicate = true) {
@@ -140,13 +171,22 @@ export class Timeline {
   }
 
   exportJSON() {
-    return JSON.stringify(this.frames, null, 2);
+    return JSON.stringify({ frames: this.frames, objects: this.objectStore }, null, 2);
   }
 
   importJSON(json) {
     try {
-      const arr = JSON.parse(json);
-      if (!Array.isArray(arr)) throw new Error('Invalid format');
+      const data = JSON.parse(json);
+      let arr;
+      if (Array.isArray(data)) {
+        arr = data;
+        this.objectStore = {};
+      } else if (data && Array.isArray(data.frames)) {
+        arr = data.frames;
+        this.objectStore = data.objects || {};
+      } else {
+        throw new Error('Invalid format');
+      }
 
       // Rétro-compatibilité : convertir l'ancien format
       const migratedFrames = arr.map(f => {
@@ -158,6 +198,18 @@ export class Timeline {
           };
         }
         return this._migrateOldFrame(f);
+      });
+
+      migratedFrames.forEach(frame => {
+        Object.entries(frame.objects).forEach(([id, obj]) => {
+          if (!this.objectStore[id]) {
+            const { src, width = 100, height = 100 } = obj;
+            this.objectStore[id] = { src, width, height };
+          }
+          delete obj.src;
+          delete obj.width;
+          delete obj.height;
+        });
       });
 
       this.frames = migratedFrames;


### PR DESCRIPTION
## Summary
- decouple DOM member references into a shared WeakMap for main puppets and onion-skin ghosts
- centralize transform constraints and lightweight scene object storage with dynamic IDs
- streamline UI updates and remove global state from pantin interactions while logging SVG normalization

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6890a2581fe8832b8fef9662698ddcc1