### PR TITLE
Improve object handling and timeline loop control

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
         <button type="button" id="prevFrame" title="Image précédente" aria-label="Image précédente">⏮️</button>
         <button type="button" id="playAnim" title="Lire l'animation" aria-label="Lire l'animation">▶️</button>
         <button type="button" id="stopAnim" title="Arrêter" aria-label="Arrêter">⏹️</button>
+        <button type="button" id="loopToggle" title="Activer/Désactiver la boucle" aria-label="Activer/Désactiver la boucle">🔁</button>
         <button type="button" id="nextFrame" title="Image suivante" aria-label="Image suivante">⏭️</button>
       </div>
       <div id="timeline-slider-container">

--- a/src/onionSkin.js
+++ b/src/onionSkin.js
@@ -27,7 +27,6 @@ export function initOnionSkin(svg, rootId, members) {
   memberList = members || [];
 
   pantinTemplate = pantinRoot.cloneNode(true);
-  stripIds(pantinTemplate);
 
   // Crée un calque dédié pour les fantômes afin de garder le DOM propre
   // et de s'assurer qu'ils sont rendus derrière le pantin principal.
@@ -74,47 +73,92 @@ export function renderOnionSkins(timeline, applyFrameToPantin) {
   // Rend les images passées
   for (let i = 0; i < settings.pastFrames; i++) {
     const frameIndex = current - (i + 1);
-    const ghost = pastGhosts[i];
+    const ghostObj = pastGhosts[i];
     if (frameIndex >= 0) {
       debugLog("Updating past ghost for frame:", frameIndex);
-      applyFrameToPantin(frames[frameIndex], ghost, memberMapStore.get(ghost));
-      ghost.style.display = '';
-      onionLayer.appendChild(ghost);
+      applyFrameToPantin(frames[frameIndex], ghostObj.container, memberMapStore.get(ghostObj.container));
+      renderGhostObjects(frames[frameIndex], ghostObj, timeline);
+      ghostObj.container.style.display = '';
+      onionLayer.appendChild(ghostObj.container);
     } else {
-      ghost.style.display = 'none';
+      ghostObj.container.style.display = 'none';
     }
   }
 
   // Rend les images futures
   for (let i = 0; i < settings.futureFrames; i++) {
     const frameIndex = current + (i + 1);
-    const ghost = futureGhosts[i];
+    const ghostObj = futureGhosts[i];
     if (frameIndex < frames.length) {
       debugLog("Updating future ghost for frame:", frameIndex);
-      applyFrameToPantin(frames[frameIndex], ghost, memberMapStore.get(ghost));
-      ghost.style.display = '';
-      onionLayer.appendChild(ghost);
+      applyFrameToPantin(frames[frameIndex], ghostObj.container, memberMapStore.get(ghostObj.container));
+      renderGhostObjects(frames[frameIndex], ghostObj, timeline);
+      ghostObj.container.style.display = '';
+      onionLayer.appendChild(ghostObj.container);
     } else {
-      ghost.style.display = 'none';
+      ghostObj.container.style.display = 'none';
     }
   }
 }
 
 function adjustGhosts(arr, count, type) {
+  const ns = 'http://www.w3.org/2000/svg';
   while (arr.length < count) {
+    const container = document.createElementNS(ns, 'g');
+    const backLayer = document.createElementNS(ns, 'g');
     const ghost = pantinTemplate.cloneNode(true);
+    const frontLayer = document.createElementNS(ns, 'g');
     const memberMap = {};
     memberList.forEach(id => {
       const el = ghost.querySelector(`#${id}`);
       if (el) memberMap[id] = el;
     });
-    memberMapStore.set(ghost, memberMap);
-    ghost.classList.add('onion-skin-ghost', `onion-skin-${type}`);
-    arr.push(ghost);
+    stripIds(ghost);
+    container.appendChild(backLayer);
+    container.appendChild(ghost);
+    container.appendChild(frontLayer);
+    container.classList.add('onion-skin-ghost', `onion-skin-${type}`);
+    memberMapStore.set(container, memberMap);
+    arr.push({ container, backLayer, frontLayer });
   }
 }
 
 function stripIds(el) {
   el.removeAttribute('id');
   Array.from(el.children).forEach(stripIds);
+}
+
+function renderGhostObjects(frame, ghostObj, timeline) {
+  const { backLayer, frontLayer, container } = ghostObj;
+  backLayer.replaceChildren();
+  frontLayer.replaceChildren();
+  Object.entries(frame.objects).forEach(([id, obj]) => {
+    const base = timeline.objectStore[id];
+    if (!base) return;
+    const img = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+    img.setAttribute('href', base.src);
+    img.setAttribute('width', base.width);
+    img.setAttribute('height', base.height);
+    if (obj.attachedTo) {
+      const seg = memberMapStore.get(container)[obj.attachedTo];
+      if (seg) {
+        const matrix = seg.getCTM();
+        const pt = svgElement.createSVGPoint();
+        pt.x = obj.x;
+        pt.y = obj.y;
+        const g = pt.matrixTransform(matrix);
+        const segAngle = Math.atan2(matrix.b, matrix.a) * 180 / Math.PI - frame.transform.rotate;
+        const totalRotate = obj.rotate + frame.transform.rotate + segAngle;
+        const totalScale = obj.scale * frame.transform.scale;
+        img.setAttribute('transform', `translate(${g.x},${g.y}) rotate(${totalRotate},${base.width/2},${base.height/2}) scale(${totalScale})`);
+      }
+    } else {
+      const totalRotate = obj.rotate + frame.transform.rotate;
+      const totalScale = obj.scale * frame.transform.scale;
+      const tx = obj.x + frame.transform.tx;
+      const ty = obj.y + frame.transform.ty;
+      img.setAttribute('transform', `translate(${tx},${ty}) rotate(${totalRotate},${base.width/2},${base.height/2}) scale(${totalScale})`);
+    }
+    (obj.layer === 'front' ? frontLayer : backLayer).appendChild(img);
+  });
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -16,6 +16,7 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
   const nextFrameBtn = document.getElementById('nextFrame');
   const playBtn = document.getElementById('playAnim');
   const stopBtn = document.getElementById('stopAnim');
+  const loopToggleBtn = document.getElementById('loopToggle');
   const addFrameBtn = document.getElementById('addFrame');
   const delFrameBtn = document.getElementById('delFrame');
   const exportAnimBtn = document.getElementById('exportAnim');
@@ -127,6 +128,7 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
   });
 
   let savedOnionSkinState = true;
+  let looping = true;
 
   playBtn.addEventListener('click', () => {
     debugLog('Play button clicked.');
@@ -139,10 +141,16 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
     updateOnionSkinSettings({ enabled: false });
     onFrameChange();
 
-    timeline.loop((frame, index) => {
+    timeline.play((frame, index) => {
       timeline.setCurrentFrame(index);
       updateUI();
-    }, fps);
+    }, () => {
+      playBtn.textContent = '▶️';
+      updateOnionSkinSettings({ enabled: savedOnionSkinState });
+      onFrameChange();
+      updateUI();
+      onSave();
+    }, fps, { loop: looping });
   });
 
   stopBtn.addEventListener('click', () => {
@@ -154,6 +162,11 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
     onFrameChange();
     updateUI();
     onSave();
+  });
+
+  loopToggleBtn.addEventListener('click', () => {
+    looping = !looping;
+    loopToggleBtn.textContent = looping ? '🔁' : '➡️';
   });
 
   // Actions sur les frames
@@ -234,6 +247,7 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
       selectedElementName.textContent = id;
     } else {
       selection = 'pantin';
+      objects.selectObject(null);
       selectedElementName.textContent = 'Pantin';
     }
     updateUI(true);
@@ -244,6 +258,7 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
     if (!id) return;
     objects.removeObject(id);
     selection = 'pantin';
+    objects.selectObject(null);
     selectedElementName.textContent = 'Pantin';
     updateUI(true);
   });


### PR DESCRIPTION
## Summary
- clear object outline when pantin is selected
- include object name in generated IDs and fix member attachment math
- render objects in onion skin and add loop toggle control

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890c6eacef8832b9f2766045a87de0e