### PR TITLE
Fix object attachment to puppet members

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -93,10 +93,7 @@ export function initObjects(svgElement, pantinRootId, timeline, memberList, onUp
     timeline.updateObject(id, { layer });
     const el = svgElement.getElementById(id);
     if (!el) return;
-    const obj = timeline.getObject(id);
-    if (obj && !obj.attachedTo) {
-      (layer === 'front' ? frontLayer : backLayer).appendChild(el);
-    }
+    (layer === 'front' ? frontLayer : backLayer).appendChild(el);
     onUpdate();
     onSave();
   }
@@ -105,18 +102,16 @@ export function initObjects(svgElement, pantinRootId, timeline, memberList, onUp
     const frame = timeline.getCurrentFrame();
     const obj = frame.objects[id];
     if (!obj) return;
-    const el = svgElement.getElementById(id);
     if (memberId) {
       const seg = pantinRoot.querySelector(`#${memberId}`);
       if (seg) {
         const inv = seg.getCTM().inverse();
         const pt = svgElement.createSVGPoint();
-        pt.x = obj.x;
-        pt.y = obj.y;
+        pt.x = obj.x + frame.transform.tx;
+        pt.y = obj.y + frame.transform.ty;
         const local = pt.matrixTransform(inv);
         obj.x = local.x;
         obj.y = local.y;
-        seg.appendChild(el);
       }
     } else if (obj.attachedTo) {
       const seg = pantinRoot.querySelector(`#${obj.attachedTo}`);
@@ -126,11 +121,9 @@ export function initObjects(svgElement, pantinRootId, timeline, memberList, onUp
         pt.x = obj.x;
         pt.y = obj.y;
         const g = pt.matrixTransform(matrix);
-        obj.x = g.x;
-        obj.y = g.y;
+        obj.x = g.x - frame.transform.tx;
+        obj.y = g.y - frame.transform.ty;
       }
-      const current = timeline.getObject(id);
-      (current.layer === 'front' ? frontLayer : backLayer).appendChild(el);
     }
     timeline.updateObject(id, { attachedTo: memberId || null, x: obj.x, y: obj.y });
     onUpdate();
@@ -242,15 +235,22 @@ export function initObjects(svgElement, pantinRootId, timeline, memberList, onUp
         (obj.layer === 'front' ? frontLayer : backLayer).appendChild(el);
         setupInteract(el, id);
       }
+      const parent = obj.layer === 'front' ? frontLayer : backLayer;
+      if (el.parentNode !== parent) parent.appendChild(el);
       if (obj.attachedTo) {
         const seg = pantinRoot.querySelector(`#${obj.attachedTo}`);
-        if (seg && el.parentNode !== seg) {
-          seg.appendChild(el);
+        if (seg) {
+          let m = svgElement.createSVGMatrix();
+          m = m.translate(obj.x, obj.y);
+          m = m.translate(obj.width / 2, obj.height / 2);
+          m = m.rotate(obj.rotate);
+          m = m.scale(obj.scale);
+          m = m.translate(-obj.width / 2, -obj.height / 2);
+          const segMatrix = seg.getCTM();
+          const res = segMatrix.multiply(m);
+          el.setAttribute('transform', `matrix(${res.a},${res.b},${res.c},${res.d},${res.e},${res.f})`);
         }
-        el.setAttribute('transform', `translate(${obj.x},${obj.y}) rotate(${obj.rotate},${obj.width/2},${obj.height/2}) scale(${obj.scale})`);
       } else {
-        const parent = obj.layer === 'front' ? frontLayer : backLayer;
-        if (el.parentNode !== parent) parent.appendChild(el);
         const totalRotate = obj.rotate + currentFrame.transform.rotate;
         const totalScale = obj.scale * currentFrame.transform.scale;
         const tx = obj.x + currentFrame.transform.tx;
@@ -260,7 +260,7 @@ export function initObjects(svgElement, pantinRootId, timeline, memberList, onUp
       if (selectedId === id) el.classList.add('selected');
       else el.classList.remove('selected');
     });
-    [frontLayer, backLayer, pantinRoot].forEach(layer => {
+    [frontLayer, backLayer].forEach(layer => {
       layer.querySelectorAll('.scene-object').forEach(el => {
         if (!existing.has(el.id)) el.remove();
       });


### PR DESCRIPTION
## Summary
- keep objects in their original layers when attaching to members
- compute combined transform from member matrices so objects retain position
- account for global frame translation so attachments preserve world coordinates

## Testing
- `node --check src/objects.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d8cf0c84832bb071fcd5eda5fcc3