### PR TITLE
Fix object attachment and timeline object import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import './style.css';
 import { initApp } from './initApp.js';
 
@@ -8,16 +8,16 @@ export default function App() {
   });
 
   useEffect(() => {
+    localStorage.setItem('inspector-collapsed', inspectorCollapsed);
+  }, [inspectorCollapsed]);
+
+  useEffect(() => {
     initApp();
   }, []);
 
-  const toggleInspector = () => {
-    setInspectorCollapsed(prev => {
-      const next = !prev;
-      localStorage.setItem('inspector-collapsed', next);
-      return next;
-    });
-  };
+  const toggleInspector = useCallback(() => {
+    setInspectorCollapsed(prev => !prev);
+  }, []);
 
   return (
     <div

--- a/src/initApp.js
+++ b/src/initApp.js
@@ -72,7 +72,7 @@ export async function initApp() {
 
     let objects;
 
-    const onFrameChange = () => {
+    const onFrameChange = async () => {
       debugLog("onFrameChange triggered. Current frame:", timeline.current);
       const frame = timeline.getCurrentFrame();
       if (!frame) return;
@@ -88,7 +88,7 @@ export async function initApp() {
       renderOnionSkins(timeline, applyFrameToPantinElement);
 
       // Render scene objects
-      objects && objects.renderObjects();
+      if (objects) await objects.renderObjects();
     };
 
     debugLog("Initializing Onion Skin...");


### PR DESCRIPTION
## Summary
- keep objects in place when attaching or detaching from pantin members
- load SVG content for objects when importing a timeline
- optimise inspector toggle with React hooks

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68916f9f4fbc832b882025fcd88f9d4f