### PR TITLE
Fix object attachment and import rendering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import './style.css';
 import { initApp } from './initApp.js';
 
@@ -11,13 +11,13 @@ export default function App() {
     initApp();
   }, []);
 
-  const toggleInspector = () => {
-    setInspectorCollapsed(prev => {
-      const next = !prev;
-      localStorage.setItem('inspector-collapsed', next);
-      return next;
-    });
-  };
+  useEffect(() => {
+    localStorage.setItem('inspector-collapsed', inspectorCollapsed);
+  }, [inspectorCollapsed]);
+
+  const toggleInspector = useCallback(() => {
+    setInspectorCollapsed(prev => !prev);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Fix attaching imported objects to puppet members by computing transforms relative to parent or stage
- Restore imported objects when loading a timeline by re-fetching their SVG and composing transforms correctly
- Persist inspector state using React hooks for cleaner re-renders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68916f9f4fbc832b882025fcd88f9d4f