### PR TITLE
Fix object controls initialization issues

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import './style.css';
 import { initApp } from './initApp.js';
 
@@ -7,8 +7,12 @@ export default function App() {
     localStorage.getItem('inspector-collapsed') === 'true'
   );
 
+  const initRef = useRef(false);
+
   useEffect(() => {
+    if (initRef.current) return;
     initApp();
+    initRef.current = true;
   }, []);
 
   useEffect(() => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -221,6 +221,7 @@ export function initUI(timeline, onFrameChange, onSave, objects) {
     const src = objectAssetSelect.value;
     if (!src) return;
     await objects.addObject(src, objectLayerSelect.value);
+    updateUI(true);
   });
 
   objectList.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- guard initialization to prevent duplicate event listeners causing double actions
- refresh object UI after adding new object so it can be attached immediately

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68919ab3c82c832bb663937ee475643f