### PR TITLE
Fix lint errors and expose timeline reference

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,11 @@ import { TimelineControls, InspectorPanel, DataPanel } from './components/UIComp
 
 export default function App() {
   const {
-    containerRef,
+    containerRef, timelineRef,
     frameIndex, frameCount, isPlaying, fps, loop,
     selectedMember, scale, rotation, onionSettings, objects,
     goToFrame, togglePlay, setLoop, setFps,
-    updateMember, updateTransform, setOnion, addObject, selectObject
+    updateMember, setOnion, addObject, selectObject
   } = useTimeline('/assets/puppet.svg');
 
   return (

--- a/src/components/UIComponents.jsx
+++ b/src/components/UIComponents.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
@@ -72,6 +72,7 @@ export function InspectorPanel({
     <Card className="p-4 space-y-4">
       <CardContent>
         <h3 className="text-xl font-semibold">Inspector</h3>
+        <div className="text-sm mb-2">Selected: {selectedMember || 'none'}</div>
         <div>
           <label className="block mb-1">Scale</label>
           <Slider
@@ -93,12 +94,35 @@ export function InspectorPanel({
         </div>
         <div>
           <h4 className="font-medium">Onion Skin</h4>
-          {/* Render onionSettings controls */}
+          <div className="flex items-center space-x-2">
+            <label>Before</label>
+            <input
+              type="number"
+              value={onionSettings.before}
+              onChange={e => onOnionSettingsChange({ ...onionSettings, before: Number(e.target.value) })}
+              className="w-16 border rounded p-1"
+            />
+            <label>After</label>
+            <input
+              type="number"
+              value={onionSettings.after}
+              onChange={e => onOnionSettingsChange({ ...onionSettings, after: Number(e.target.value) })}
+              className="w-16 border rounded p-1"
+            />
+          </div>
         </div>
         <div>
           <h4 className="font-medium">Objects</h4>
           <Button onClick={onAddObject}>Add Object</Button>
-          {/* Render list of objects */}
+          <ul className="mt-2 space-y-1">
+            {objects.map(obj => (
+              <li key={obj.id}>
+                <Button variant={obj.selected ? 'default' : 'secondary'} onClick={() => onSelectObject(obj.id)}>
+                  {obj.name || obj.id}
+                </Button>
+              </li>
+            ))}
+          </ul>
         </div>
       </CardContent>
     </Card>

--- a/src/initApp.js
+++ b/src/initApp.js
@@ -50,11 +50,6 @@ export async function initApp() {
       });
     };
 
-    const onSave = () => {
-      localStorage.setItem('animation', timeline.exportJSON());
-      debugLog("Animation sauvegardée.");
-    };
-
     const savedData = localStorage.getItem('animation');
     if (savedData) {
       try {
@@ -74,10 +69,6 @@ export async function initApp() {
       // Apply to main pantin
       applyFrameToPantinElement(frame, pantinRootGroup);
 
-      // Update inspector values
-      scaleValueEl.value = frame.transform.scale.toFixed(2);
-      rotateValueEl.value = Math.round(frame.transform.rotate);
-
       // Render onion skins
       renderOnionSkins(timeline, applyFrameToPantinElement);
 
@@ -86,14 +77,14 @@ export async function initApp() {
     });
 
     // Quand un membre est mis à jour (scale / rotate)…
-timeline.on('memberTransform', ({ id, scale, rotate }) => {
-  // On récupère la frame courante et on ré-applique tout
-  const frame = timeline.getCurrentFrame();
-  if (!frame) return;
-  applyFrameToPantinElement(frame, pantinRootGroup);
-  renderOnionSkins(timeline, applyFrameToPantinElement);
-  objects && objects.renderObjects();
-});
+    timeline.on('memberTransform', () => {
+      // On récupère la frame courante et on ré-applique tout
+      const frame = timeline.getCurrentFrame();
+      if (!frame) return;
+      applyFrameToPantinElement(frame, pantinRootGroup);
+      renderOnionSkins(timeline, applyFrameToPantinElement);
+      objects && objects.renderObjects();
+    });
 
 // Quand la transformation globale change (translate / scale / rotate)…
 timeline.on('transformChange', transform => {

--- a/src/useTimeline.js
+++ b/src/useTimeline.js
@@ -1,4 +1,3 @@
-import { memberMapStore } from './memberMapStore';
 import { useEffect, useRef, useState } from 'react';
 import { loadSVG } from './svgLoader';
 import { Timeline } from './timeline';
@@ -32,7 +31,7 @@ export function useTimeline() {
       containerRef.current.id = THEATRE_ID;
 
       // Charger et injecter le SVG
-      const { svgElement, memberList, pivots } = await loadSVG(SVG_URL, THEATRE_ID);
+      const { svgElement, memberList } = await loadSVG(SVG_URL, THEATRE_ID);
       if (!mounted) return;
       const svgRoot = svgElement;
 
@@ -95,6 +94,7 @@ export function useTimeline() {
 
   return {
     containerRef,
+    timelineRef,
     frameIndex, frameCount, isPlaying, fps, loop,
     selectedMember, scale, rotation, onionSettings, objects,
     goToFrame, togglePlay, setLoop: setLoopAction, setFps: setFpsAction,

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- expose timeline ref in useTimeline and use in App
- enhance InspectorPanel with onion skin and object controls
- clean up unused code and define ESM __dirname for Vite

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6892368b6680832bb41b6aec5780d9cf