### PR TITLE
fix: resolve lint errors and add timeline reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,10 +5,21 @@ import { TimelineControls, InspectorPanel, DataPanel } from './components/UIComp
 export default function App() {
   const {
     containerRef,
-    frameIndex, frameCount, isPlaying, fps, loop,
-    selectedMember, scale, rotation, onionSettings, objects,
-    goToFrame, togglePlay, setLoop, setFps,
-    updateMember, updateTransform, setOnion, addObject, selectObject
+    frameIndex,
+    frameCount,
+    isPlaying,
+    fps,
+    loop,
+    selectedMember,
+    scale,
+    rotation,
+    goToFrame,
+    togglePlay,
+    setLoop,
+    setFps,
+    updateMember,
+    addObject,
+    timelineRef,
   } = useTimeline('/assets/puppet.svg');
 
   return (
@@ -29,22 +40,24 @@ export default function App() {
         />
 
         <InspectorPanel
-          selectedMember={selectedMember}
           scale={scale}
           rotation={rotation}
-          onionSettings={onionSettings}
           onScaleChange={v => updateMember(selectedMember, { scale: v })}
           onRotationChange={v => updateMember(selectedMember, { rotate: v })}
-          onOnionSettingsChange={setOnion}
           onAddObject={addObject}
-          onSelectObject={selectObject}
-          objects={objects}
         />
 
         <DataPanel
-          onExport={() => timelineRef.current.exportJSON()}
-          onImport={e => timelineRef.current.importJSON(e.target.files[0])}
-          onReset={() => timelineRef.current.reset()}
+          onExport={() => timelineRef.current?.exportJSON()}
+          onImport={e => {
+            const file = e.target.files[0];
+            if (file) {
+              const reader = new FileReader();
+              reader.onload = evt => timelineRef.current?.importJSON(evt.target.result);
+              reader.readAsText(file);
+            }
+          }}
+          onReset={() => timelineRef.current?.reset()}
         />
       </div>
 

--- a/src/components/UIComponents.jsx
+++ b/src/components/UIComponents.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
@@ -57,16 +57,11 @@ export function TimelineControls({
 
 // Inspector panel: member scale, rotation, object management, onion skin settings
 export function InspectorPanel({
-  selectedMember,
   scale,
   rotation,
-  onionSettings,
   onScaleChange,
   onRotationChange,
-  onOnionSettingsChange,
   onAddObject,
-  onSelectObject,
-  objects
 }) {
   return (
     <Card className="p-4 space-y-4">

--- a/src/initApp.js
+++ b/src/initApp.js
@@ -66,6 +66,8 @@ export async function initApp() {
     }
 
     let objects;
+    const scaleValueEl = document.getElementById('scaleValue');
+    const rotateValueEl = document.getElementById('rotateValue');
 
     timeline.on('frameChange', () => {
       const frame = timeline.getCurrentFrame();
@@ -86,7 +88,7 @@ export async function initApp() {
     });
 
     // Quand un membre est mis à jour (scale / rotate)…
-timeline.on('memberTransform', ({ id, scale, rotate }) => {
+    timeline.on('memberTransform', () => {
   // On récupère la frame courante et on ré-applique tout
   const frame = timeline.getCurrentFrame();
   if (!frame) return;
@@ -117,7 +119,15 @@ timeline.on('transformChange', transform => {
       grabId: GRAB_ID,
     };
 
-    objects = initObjects(svgElement, PANTIN_ROOT_ID, timeline, attachableMembers);
+    const onObjectsUpdate = () => {};
+    objects = initObjects(
+      svgElement,
+      PANTIN_ROOT_ID,
+      timeline,
+      attachableMembers,
+      onObjectsUpdate,
+      onSave
+    );
 
     debugLog("Setting up member interactions...");
     const teardownMembers = setupInteractions(svgElement, memberList, pivots, timeline);

--- a/src/timeline.js
+++ b/src/timeline.js
@@ -258,6 +258,14 @@ export class Timeline {
     this.emit('playToggle', false);
   }
 
+  reset() {
+    this.stop();
+    this.frames = [this.createEmptyFrame()];
+    this.current = 0;
+    this.objectStore = {};
+    this.emit('frameChange', this.current);
+  }
+
   exportJSON() {
     return JSON.stringify({ frames: this.frames, objects: this.objectStore }, null, 2);
   }

--- a/src/useTimeline.js
+++ b/src/useTimeline.js
@@ -1,4 +1,3 @@
-import { memberMapStore } from './memberMapStore';
 import { useEffect, useRef, useState } from 'react';
 import { loadSVG } from './svgLoader';
 import { Timeline } from './timeline';
@@ -32,7 +31,7 @@ export function useTimeline() {
       containerRef.current.id = THEATRE_ID;
 
       // Charger et injecter le SVG
-      const { svgElement, memberList, pivots } = await loadSVG(SVG_URL, THEATRE_ID);
+      const { svgElement, memberList } = await loadSVG(SVG_URL, THEATRE_ID);
       if (!mounted) return;
       const svgRoot = svgElement;
 
@@ -95,10 +94,26 @@ export function useTimeline() {
 
   return {
     containerRef,
-    frameIndex, frameCount, isPlaying, fps, loop,
-    selectedMember, scale, rotation, onionSettings, objects,
-    goToFrame, togglePlay, setLoop: setLoopAction, setFps: setFpsAction,
-    updateMember, updateTransform, setOnion, addObject, selectObject
+    frameIndex,
+    frameCount,
+    isPlaying,
+    fps,
+    loop,
+    selectedMember,
+    scale,
+    rotation,
+    onionSettings,
+    objects,
+    goToFrame,
+    togglePlay,
+    setLoop: setLoopAction,
+    setFps: setFpsAction,
+    updateMember,
+    updateTransform,
+    setOnion,
+    addObject,
+    selectObject,
+    timelineRef,
   };
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- expose timeline ref to React components and wire JSON import/export/reset
- clean up unused props and imports in UI components
- add reset method to timeline and align init workflow
- configure Vite with `__dirname` in ESM mode

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892368b6680832bb41b6aec5780d9cf